### PR TITLE
Update token in sync-to-fork workflow

### DIFF
--- a/.github/workflows/sync-to-fork.yml
+++ b/.github/workflows/sync-to-fork.yml
@@ -14,7 +14,7 @@ jobs:
       - name: Checkout main
         uses: actions/checkout@v4
         with:
-          token: ${{ secrets.PERSONAL_ACCESS_TOKEN }}
+          token: ${{ secrets.GITHUB_TOKEN }}
           fetch-depth: 0
           ref: main
 


### PR DESCRIPTION
## 📌 Summary

Org 레포 사용 토큰 `GITHUB_TOKEN`으로 변경

