### PR TITLE
feat(front): 분석 시작 버튼 + 진행 상태 색상 정비

### DIFF
--- a/src/app/(app)/workspace/[workspaceId]/WorkspaceDetailClient.tsx
+++ b/src/app/(app)/workspace/[workspaceId]/WorkspaceDetailClient.tsx
@@ -15,7 +15,7 @@ import { AdminLoading } from '@/components/ui/AdminLoading';
 import { WeeklyReportCard } from '@/components/workspace/detail/WeeklyReportCard';
 import { EditProfileModal } from '@/components/workspace/detail/EditProfileModal';
 import { BlacklistModal } from '@/components/workspace/detail/BlacklistModal';
-import { CreateReportButton } from '@/components/workspace/detail/CreateReportButton';
+import { StartAnalysisButton } from '@/components/workspace/detail/StartAnalysisButton';
 import { ReportListItem } from '@/components/workspace/detail/ReportListItem';
 import { useMyRole } from '@/hooks/user/useUserQuery';
 import { ChevronRight, Pencil, ShieldOff } from 'lucide-react';
@@ -108,6 +108,12 @@ export function WorkspaceDetailClient({ workspaceId }: WorkspaceDetailClientProp
     [progressList]
   );
 
+  // 분석 미시작 initial draft: super_admin 이 첫 분석을 트리거할 대상
+  const pendingInitial = useMemo(() => {
+    if (!reports) return null;
+    return reports.find((r) => r.type === 'initial' && r.status === 'draft') ?? null;
+  }, [reports]);
+
   return (
     <div className="flex w-full px-4 sm:px-6 lg:px-8 py-6 sm:py-10 min-h-full">
       <div className="w-full max-w-3xl mx-auto flex flex-col gap-7 min-h-full">
@@ -129,6 +135,13 @@ export function WorkspaceDetailClient({ workspaceId }: WorkspaceDetailClientProp
               <TickerBadge ticker={workspace.ticker} />
             </div>
             <div className="shrink-0 flex items-center gap-2">
+              {isSuperAdmin && pendingInitial && (
+                <StartAnalysisButton
+                  workspaceId={workspaceId}
+                  reportId={pendingInitial.id}
+                  size="sm"
+                />
+              )}
               <button
                 onClick={() => setShowBlacklist(true)}
                 className="inline-flex items-center gap-1.5 text-xs font-medium text-slate-500 bg-white border border-slate-200 rounded-lg px-3 py-1.5 hover:bg-slate-50 hover:border-slate-300 hover:text-slate-700 transition-colors cursor-pointer"
@@ -192,9 +205,11 @@ export function WorkspaceDetailClient({ workspaceId }: WorkspaceDetailClientProp
           {isPending && <AdminLoading message="보고서 불러오는 중" />}
 
           {!isPending && (!reports || reports.length === 0) && (
-            <div className="bg-white rounded-2xl border border-dashed border-slate-200 shadow-sm py-14 flex flex-col items-center gap-4">
+            <div className="bg-white rounded-2xl border border-dashed border-slate-200 shadow-sm py-14 flex flex-col items-center gap-2">
               <span className="text-sm text-slate-400">아직 생성된 보고서가 없습니다.</span>
-              <CreateReportButton workspaceId={workspaceId} />
+              <span className="text-xs text-slate-400">
+                워크스페이스 생성 시 자동으로 보고서가 만들어집니다. 잠시 후 새로고침해 주세요.
+              </span>
             </div>
           )}
 

--- a/src/app/api/admin/create-user/route.ts
+++ b/src/app/api/admin/create-user/route.ts
@@ -60,7 +60,7 @@ export async function POST(request: NextRequest) {
         .eq('id', userId);
       if (profErr) throw profErr;
     } else {
-      const { error: rpcErr } = await supabaseAdmin.rpc(
+      const { data: rpcData, error: rpcErr } = await supabaseAdmin.rpc(
         'create_user_workspace_bundle',
         {
           p_user_id: userId,
@@ -74,6 +74,21 @@ export async function POST(request: NextRequest) {
         },
       );
       if (rpcErr) throw rpcErr;
+
+      const bundle = rpcData as {
+        workspace_id: string;
+        report_id: string;
+        period_start: string;
+        period_end: string;
+      };
+      return NextResponse.json({
+        id: userId,
+        email,
+        workspace_id: bundle.workspace_id,
+        report_id: bundle.report_id,
+        period_start: bundle.period_start,
+        period_end: bundle.period_end,
+      });
     }
 
     return NextResponse.json({ id: userId, email });

--- a/src/components/report/RiskContent.tsx
+++ b/src/components/report/RiskContent.tsx
@@ -34,6 +34,9 @@ export function RiskContent({ workspaceId, reportId, editable = false, allowRepo
   }, [riskReports]);
 
   const isDaily = report?.type === 'daily';
+  // initial 보고서에 속한 항목은 신고 대행 요청 불가 (DB trigger 도 함께 enforce)
+  const isInitial = report?.type === 'initial';
+  const effectiveAllowReport = allowReport && !isInitial;
 
   return (
     <div className="print-break">
@@ -47,7 +50,7 @@ export function RiskContent({ workspaceId, reportId, editable = false, allowRepo
             riskReportBySourceId={riskReportBySourceId}
             onCancelReport={deleteMutation.mutate}
             editable={editable}
-            allowReport={allowReport}
+            allowReport={effectiveAllowReport}
             pdfMode={pdfMode}
           />
         </div>

--- a/src/components/workspace/detail/ReportListItem.tsx
+++ b/src/components/workspace/detail/ReportListItem.tsx
@@ -4,7 +4,7 @@ import { useRouter } from 'next/navigation';
 import { ChevronDown, ChevronUp, ChevronRight, AlertCircle } from 'lucide-react';
 import type { Report, ReportProgress } from '@/lib/api/workspaceApi';
 import { ALL_PLATFORMS, PLATFORM_LABELS, getReportHealth } from '@/utils/workspace';
-import { STATUS_CONFIG, HEALTH_STRIPE } from './styles';
+import { STATUS_CONFIG, STATUS_FALLBACK, HEALTH_STRIPE } from './styles';
 import { ReportProgressPanel } from './ReportProgressPanel';
 
 /** 채널별 + (비일간일 때) 총평·전략 mini dot. 닫힌 카드에서도 어느 단계가 문제인지 훑어볼 수 있게 */
@@ -17,10 +17,7 @@ function ChannelMiniDots({
 }) {
   const sessionMap = new Map(progress?.sessions.map((s) => [s.platform_id, s]) ?? []);
   const dotClassFor = (status: string) =>
-    status === 'done' ? 'bg-emerald-400' :
-    status === 'failed' ? 'bg-red-400' :
-    status === 'pending' ? 'bg-slate-200' :
-    'bg-amber-400 animate-pulse';
+    (STATUS_CONFIG[status] ?? STATUS_FALLBACK).dot;
 
   const summaryStatus = progress?.hasSummary ? 'done' : 'pending';
   const strategyStatus = (progress?.strategyCategories?.length ?? 0) > 0 ? 'done' : 'pending';
@@ -81,17 +78,21 @@ export function ReportListItem({
         ? '일간 보고서'
         : '주간 보고서';
   const isAutoPublished = report.type === 'daily' && report.status === 'published';
+  const isNotAnalyzed = !progress || progress.sessions.length === 0;
   const statusColor = isAutoPublished
     ? 'bg-violet-50 text-violet-700'
     : report.status === 'published'
       ? 'bg-emerald-50 text-emerald-700'
-      : 'bg-amber-50 text-amber-700';
+      : isNotAnalyzed
+        ? 'bg-slate-100 text-slate-600'
+        : 'bg-amber-50 text-amber-700';
   const statusLabel = isAutoPublished
     ? '자동 발행'
     : report.status === 'published'
       ? '검토 완료'
-      : '검토 대기';
-  const isNotAnalyzed = !progress || progress.sessions.length === 0;
+      : isNotAnalyzed
+        ? '분석 대기'
+        : '검토 대기';
   const periodLabel = report.type === 'daily' ? periodStart : `${periodStart} ~ ${periodEnd}`;
   const health = getReportHealth(progress);
   const failedCount = progress?.sessions.filter((s) => s.status === 'failed').length ?? 0;

--- a/src/components/workspace/detail/ReportProgressPanel.tsx
+++ b/src/components/workspace/detail/ReportProgressPanel.tsx
@@ -11,12 +11,8 @@ import { PLATFORM_LABELS, FAILED_REASON_LABELS, ALL_PLATFORMS } from '@/utils/wo
 import { STATUS_CONFIG, STATUS_FALLBACK } from './styles';
 
 function SessionStatusDot({ status }: { status: string }) {
-  const dotColor =
-    status === 'done' ? 'bg-emerald-400' :
-    status === 'failed' ? 'bg-red-400' :
-    status === 'pending' ? 'bg-slate-300' :
-    'bg-amber-400 animate-pulse';
-  return <span className={`w-1.5 h-1.5 rounded-full ${dotColor}`} />;
+  const cfg = STATUS_CONFIG[status] ?? STATUS_FALLBACK;
+  return <span className={`w-1.5 h-1.5 rounded-full ${cfg.dot}`} />;
 }
 
 function FailedPlatformRow({
@@ -183,10 +179,19 @@ export function ReportProgressPanel({
           )}
           <div className="grid grid-cols-2 gap-1.5">
             {(() => {
+              // dot 색 매핑: 분석 시작 전 = pending, 채널 분석은 끝났는데 finalize 안 끝나면 crawling, 끝나면 done
+              const sessionsAllDone =
+                progress.sessions.length > 0 &&
+                progress.sessions.every((s) => s.status === 'done');
+              const dotStatus = progress.hasSummary
+                ? 'done'
+                : sessionsAllDone
+                  ? 'crawling'
+                  : 'pending';
               const cfg = progress.hasSummary ? STATUS_CONFIG.done : STATUS_FALLBACK;
               return (
                 <div className={`flex items-center gap-2 border rounded-lg px-3 py-2 ${cfg.bg} ${cfg.border}`}>
-                  <SessionStatusDot status={progress.hasSummary ? 'done' : 'crawling'} />
+                  <SessionStatusDot status={dotStatus} />
                   <span className="text-xs text-slate-600 font-medium">총평</span>
                   <span className={`text-xs font-semibold ml-auto ${cfg.color}`}>
                     {progress.hasSummary ? '완료' : '작업 전'}
@@ -196,10 +201,14 @@ export function ReportProgressPanel({
             })()}
             {(() => {
               const done = progress.strategyCategories.length > 0;
+              const sessionsAllDone =
+                progress.sessions.length > 0 &&
+                progress.sessions.every((s) => s.status === 'done');
+              const dotStatus = done ? 'done' : sessionsAllDone ? 'crawling' : 'pending';
               const cfg = done ? STATUS_CONFIG.done : STATUS_FALLBACK;
               return (
                 <div className={`flex items-center gap-2 border rounded-lg px-3 py-2 ${cfg.bg} ${cfg.border}`}>
-                  <SessionStatusDot status={done ? 'done' : 'crawling'} />
+                  <SessionStatusDot status={dotStatus} />
                   <span className="text-xs text-slate-600 font-medium">대응 전략</span>
                   <span className={`text-xs font-semibold ml-auto ${cfg.color}`}>
                     {done ? `${progress.strategyCategories.length}개 채널` : '작업 전'}

--- a/src/components/workspace/detail/StartAnalysisButton.tsx
+++ b/src/components/workspace/detail/StartAnalysisButton.tsx
@@ -1,0 +1,79 @@
+'use client';
+
+import { useState } from 'react';
+import { useQueryClient } from '@tanstack/react-query';
+import { toast } from 'sonner';
+import { workspaceKeys } from '@/hooks/workspace/workspaceKeys';
+import { createClient } from '@/lib/supabase/client';
+
+interface StartAnalysisButtonProps {
+  workspaceId: string;
+  reportId: string;
+  /** 외부 사유로 비활성화하고 싶을 때 (예: 이미 진행 중) */
+  disabled?: boolean;
+  size?: 'sm' | 'md';
+}
+
+export function StartAnalysisButton({
+  workspaceId,
+  reportId,
+  disabled,
+  size = 'md',
+}: StartAnalysisButtonProps) {
+  const [loading, setLoading] = useState(false);
+  const queryClient = useQueryClient();
+
+  const handleStart = async () => {
+    setLoading(true);
+    try {
+      const supabase = createClient();
+      const {
+        data: { session },
+      } = await supabase.auth.getSession();
+      if (!session) {
+        toast.error('인증이 필요합니다.');
+        return;
+      }
+
+      const res = await fetch(`${process.env.NEXT_PUBLIC_API_URL}/api/pipeline/all`, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          Authorization: `Bearer ${session.access_token}`,
+        },
+        body: JSON.stringify({
+          workspace_id: workspaceId,
+          report_id: reportId,
+          triggered_by: 'manual',
+        }),
+      });
+
+      if (!res.ok) {
+        const err = await res.json().catch(() => ({}));
+        throw new Error(err?.detail ?? '분석 시작 실패');
+      }
+
+      queryClient.invalidateQueries({ queryKey: workspaceKeys.reports(workspaceId) });
+      queryClient.invalidateQueries({ queryKey: workspaceKeys.progress(workspaceId) });
+      toast.success('분석을 시작했습니다.');
+    } catch (e: unknown) {
+      const message = e instanceof Error ? e.message : '분석 시작에 실패했습니다.';
+      toast.error(message);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const sizeClass =
+    size === 'sm' ? 'px-3 py-1.5 text-xs rounded-lg' : 'px-5 py-2.5 text-sm rounded-xl';
+
+  return (
+    <button
+      onClick={handleStart}
+      disabled={loading || disabled}
+      className={`bg-blue-600 text-white font-semibold hover:bg-blue-700 active:scale-95 transition-all duration-150 cursor-pointer disabled:opacity-50 disabled:cursor-not-allowed ${sizeClass}`}
+    >
+      {loading ? '시작 중...' : disabled ? '분석 진행 중' : '분석 시작'}
+    </button>
+  );
+}

--- a/src/components/workspace/detail/styles.ts
+++ b/src/components/workspace/detail/styles.ts
@@ -7,13 +7,14 @@ export const WEEKLY_PILL_STYLES: Record<WeeklyPillState, { bg: string; border: s
   running: { bg: 'bg-amber-50',   border: 'border-amber-200',   text: 'text-amber-700',   dot: 'bg-amber-400 animate-pulse' },
 };
 
-export const STATUS_CONFIG: Record<string, { label: string; color: string; bg: string; border: string }> = {
-  pending:    { label: '작업 전',       color: 'text-slate-400',   bg: 'bg-slate-50',   border: 'border-slate-100'   },
-  crawling:   { label: '크롤링 중',     color: 'text-blue-500',    bg: 'bg-blue-50',    border: 'border-blue-100'    },
-  analyzing:  { label: '분석 중',       color: 'text-amber-500',   bg: 'bg-amber-50',   border: 'border-amber-100'   },
-  clustering: { label: '클러스터링 중', color: 'text-violet-500',  bg: 'bg-violet-50',  border: 'border-violet-100'  },
-  done:       { label: '완료',          color: 'text-emerald-500', bg: 'bg-emerald-50', border: 'border-emerald-100' },
-  failed:     { label: '실패',          color: 'text-red-500',     bg: 'bg-red-50',     border: 'border-red-100'     },
+export const STATUS_CONFIG: Record<string, { label: string; color: string; bg: string; border: string; dot: string }> = {
+  pending:           { label: '작업 전',       color: 'text-slate-400',   bg: 'bg-slate-50',   border: 'border-slate-100',   dot: 'bg-slate-300' },
+  crawling:          { label: '크롤링 중',     color: 'text-blue-500',    bg: 'bg-blue-50',    border: 'border-blue-100',    dot: 'bg-blue-400 animate-pulse' },
+  pending_analysis:  { label: '분석 대기',     color: 'text-indigo-500',  bg: 'bg-indigo-50',  border: 'border-indigo-100',  dot: 'bg-indigo-300' },
+  analyzing:         { label: '분석 중',       color: 'text-amber-500',   bg: 'bg-amber-50',   border: 'border-amber-100',   dot: 'bg-amber-400 animate-pulse' },
+  clustering:        { label: '클러스터링 중', color: 'text-violet-500',  bg: 'bg-violet-50',  border: 'border-violet-100',  dot: 'bg-violet-400 animate-pulse' },
+  done:              { label: '완료',          color: 'text-emerald-500', bg: 'bg-emerald-50', border: 'border-emerald-100', dot: 'bg-emerald-400' },
+  failed:            { label: '실패',          color: 'text-red-500',     bg: 'bg-red-50',     border: 'border-red-100',     dot: 'bg-red-400' },
 };
 
 export const STATUS_FALLBACK = STATUS_CONFIG.pending;

--- a/src/lib/api/reportApi.ts
+++ b/src/lib/api/reportApi.ts
@@ -58,18 +58,48 @@ async function getReportMeta(reportId: string): Promise<ReportMeta> {
   const [reportRes, sessionsRes] = await Promise.all([
     supabase
       .from('reports')
-      .select('type, period_start, period_end, sir_score')
+      .select('workspace_id, type, period_start, period_end, sir_score')
       .eq('id', reportId)
       .maybeSingle(),
     supabase.from('sessions').select('id').eq('report_id', reportId),
   ]);
 
+  let sessionIds: string[] = (sessionsRes.data ?? []).map((s) => s.id);
+
+  // 일간 구독자의 weekly compile: 자체 sessions 가 없는 경우
+  // period 안의 daily reports 들의 sessions 합집합으로 fallback.
+  // 백엔드 _resolve_sessions_for_report 와 동일한 분기.
+  const r = reportRes.data;
+  if (
+    sessionIds.length === 0 &&
+    r?.type === 'weekly' &&
+    r?.workspace_id &&
+    r?.period_start &&
+    r?.period_end
+  ) {
+    const dailyReports = await supabase
+      .from('reports')
+      .select('id')
+      .eq('workspace_id', r.workspace_id)
+      .eq('type', 'daily')
+      .gte('period_start', r.period_start)
+      .lte('period_end', r.period_end);
+    const dailyReportIds = (dailyReports.data ?? []).map((row) => row.id);
+    if (dailyReportIds.length > 0) {
+      const dailySessions = await supabase
+        .from('sessions')
+        .select('id')
+        .in('report_id', dailyReportIds);
+      sessionIds = (dailySessions.data ?? []).map((s) => s.id);
+    }
+  }
+
   const meta: ReportMeta = {
-    sessionIds: (sessionsRes.data ?? []).map((s) => s.id),
-    periodStart: reportRes.data?.period_start ?? '',
-    periodEnd: reportRes.data?.period_end ?? '',
-    sirScore: reportRes.data?.sir_score ?? 0,
-    type: reportRes.data?.type ?? '',
+    sessionIds,
+    periodStart: r?.period_start ?? '',
+    periodEnd: r?.period_end ?? '',
+    sirScore: r?.sir_score ?? 0,
+    type: r?.type ?? '',
   };
 
   reportMetaCache.set(reportId, meta);
@@ -375,21 +405,26 @@ export async function getNewsClusters(workspaceId: string, reportId?: string): P
     const meta = await getReportMeta(reportId);
     if (meta.sessionIds.length === 0) return [];
 
-    const [clusters, items] = await Promise.all([
-      fetchAllPaged<any>((from, to) =>
-        supabase.from('news_clusters')
-          .select('id, representative_title, sentiment, summary')
-          .eq('workspace_id', workspaceId).eq('is_relevant', true)
-          .in('session_id', meta.sessionIds)
-          .order('created_at', { ascending: false })
-          .range(from, to)),
-      fetchAllPaged<any>((from, to) =>
-        supabase.from('news_items')
-          .select('cluster_id, title, source, link')
-          .eq('workspace_id', workspaceId).not('cluster_id', 'is', null)
-          .in('session_id', meta.sessionIds)
-          .range(from, to)),
-    ]);
+    // articles 를 먼저 fetch — 그 articles 의 cluster_id 합집합으로 cluster 조회.
+    // cross-session matching 도입 후엔 cluster row 의 session_id 가 처음 만든 session 만 가리키므로
+    // session_id IN 으로 cluster 를 찾으면 다른 session 에서 매칭 추가된 cluster 가 누락된다.
+    const items = await fetchAllPaged<any>((from, to) =>
+      supabase.from('news_items')
+        .select('cluster_id, title, source, link')
+        .eq('workspace_id', workspaceId).not('cluster_id', 'is', null)
+        .in('session_id', meta.sessionIds)
+        .range(from, to));
+
+    const clusterIds = Array.from(new Set(items.map((i: any) => i.cluster_id).filter(Boolean)));
+    if (clusterIds.length === 0) return [];
+
+    const clusters = await fetchAllPaged<any>((from, to) =>
+      supabase.from('news_clusters')
+        .select('id, representative_title, sentiment, summary')
+        .eq('workspace_id', workspaceId).eq('is_relevant', true)
+        .in('id', clusterIds)
+        .order('created_at', { ascending: false })
+        .range(from, to));
 
     const itemsByCluster = new Map<string, { title: string; source: string; link: string }[]>();
     for (const item of items) {


### PR DESCRIPTION
v18:
- StartAnalysisButton (super_admin 전용) — WorkspaceDetailClient 헤더 노출
- /api/admin/create-user 가 RPC JSONB 응답에서 workspace_id, report_id 받아 반환
- RiskContent: report.type='initial' 일 때 allowReport 강제 false (이중 방어)
- reportApi.getReportMeta / getNewsClusters: weekly 자체 sessions 0건이면 period 안 daily reports 의 sessions / cluster_id 합집합으로 fallback

오늘:
- STATUS_CONFIG 에 pending_analysis '분석 대기' 추가 (indigo — blue/violet 와 분리)
- 모든 상태에 dot 색 매핑, ReportProgressPanel/ReportListItem 의 dot 이 STATUS_CONFIG.dot 따르도록 통일 (amber 하드코딩 제거)

