### PR TITLE
feat(front): 보고서 0건 케이스 UI/UX 보강 + 채널 카드 미렌더링 버그 fix

### DIFF
--- a/src/components/chart/ChartCanvas.tsx
+++ b/src/components/chart/ChartCanvas.tsx
@@ -59,7 +59,7 @@ export function ChartCanvas({
   return (
     <div
       ref={ref}
-      className={className}
+      className={className ?? ''}
       style={{ width: wrapperWidth, height: wrapperHeight, ...style }}
     >
       {size && finalWidth > 0 && finalHeight > 0 && (

--- a/src/components/report/Highlight.tsx
+++ b/src/components/report/Highlight.tsx
@@ -106,8 +106,21 @@ export function Highlight({ workspaceId, reportId, pdfMode = false, editable = f
     [sirScore, avgScore, workspace?.company_name, sirRanking, pdfMode, isDaily, isInitial],
   );
 
+  const isNoData = totalItems === 0;
+
   return (
     <ReportSection icon={<WeeklyHighlightIcon size={36} />} title={isDaily ? '일간 하이라이트' : isInitial ? '월간 하이라이트' : '주간 하이라이트'}>
+      {isNoData && (
+        <div className="bg-amber-50 border border-amber-200 rounded-lg px-4 py-3 flex items-start gap-3">
+          <span className="text-amber-700 text-base shrink-0 leading-none mt-0.5">⚠</span>
+          <div className="flex flex-col gap-0.5">
+            <span className="text-sm font-semibold text-amber-800">이번 기간 수집된 데이터가 없습니다.</span>
+            <span className="text-xs text-amber-700 leading-relaxed">
+              SIR 점수와 채널별 지표는 직전 일자 기준으로 표시되며, 변화량은 산출되지 않습니다.
+            </span>
+          </div>
+        </div>
+      )}
       <div className="print-keep"><Snapshot {...snapshotProps} /></div>
       {!isDaily && (
         <>

--- a/src/components/report/ReportSection.tsx
+++ b/src/components/report/ReportSection.tsx
@@ -71,7 +71,7 @@ export function ReportSubSection({
           <p className="text-xs lg:text-sm font-normal text-text-muted">{description}</p>
         )}
       </div>
-      <div className={`${className}`}>{children}</div>
+      <div className={className ?? ''}>{children}</div>
     </div>
   );
 }

--- a/src/components/report/RiskContent.tsx
+++ b/src/components/report/RiskContent.tsx
@@ -3,7 +3,7 @@
 import { useMemo, useState } from 'react';
 import dynamic from 'next/dynamic';
 import { ShieldAlert } from 'lucide-react';
-import { useRiskItemsSuspense, useRiskReportsSuspense, useReportInfoSuspense } from '@/hooks/report/useReportQuery';
+import { useRiskItemsSuspense, useRiskReportsSuspense, useReportInfoSuspense, useChannelItemsSuspense } from '@/hooks/report/useReportQuery';
 import { useDeleteRiskReport } from '@/hooks/report/useReportMutation';
 import { useWorkspaceSubscription } from '@/hooks/workspace/useWorkspaceQuery';
 import { ReportSection } from '@/components/report/ReportSection';
@@ -32,9 +32,14 @@ export function RiskContent({ workspaceId, reportId, editable = false, allowRepo
   const { data: report } = useReportInfoSuspense(reportId);
   const { data: riskItems } = useRiskItemsSuspense(workspaceId, reportId);
   const { data: riskReports } = useRiskReportsSuspense(workspaceId, reportId);
+  const { data: channelItems } = useChannelItemsSuspense(workspaceId, reportId);
   const { data: subscription } = useWorkspaceSubscription(workspaceId);
   const deleteMutation = useDeleteRiskReport(workspaceId);
   const [showUpgrade, setShowUpgrade] = useState(false);
+
+  // 그 기간 수집된 콘텐츠가 0건이면 "리스크 0건" vs "데이터 부족" 의미 혼동.
+  // 0건이면 분석 불가 안내, 그 외엔 RiskDetectionTable 의 기존 empty state ("리스크 없음") 유지.
+  const isNoData = channelItems.length === 0;
 
   const { reportedSourceIds, riskReportBySourceId, processedSourceIds } = useMemo(() => {
     const ids = new Set<string>();
@@ -58,18 +63,27 @@ export function RiskContent({ workspaceId, reportId, editable = false, allowRepo
     <div className="print-break">
       <ReportSection id="section-risk" icon={<LiskContentIcon size={36} />} title="리스크 콘텐츠 관리">
         <div className="print-keep">
-          <RiskDetectionTable
-            riskItems={riskItems}
-            workspaceId={workspaceId}
-            reportId={reportId}
-            reportedSourceIds={reportedSourceIds}
-            riskReportBySourceId={riskReportBySourceId}
-            processedSourceIds={processedSourceIds}
-            onCancelReport={deleteMutation.mutate}
-            editable={editable}
-            allowReport={effectiveAllowReport}
-            pdfMode={pdfMode}
-          />
+          {isNoData ? (
+            <ReportCard px={20} py={32}>
+              <div className="flex flex-col items-center justify-center gap-2 py-8 text-center">
+                <span className="text-sm font-semibold text-text-muted">이번 기간 수집된 데이터가 없습니다.</span>
+                <span className="text-xs text-text-muted">분석할 콘텐츠가 없어 리스크 탐지가 보류됩니다.</span>
+              </div>
+            </ReportCard>
+          ) : (
+            <RiskDetectionTable
+              riskItems={riskItems}
+              workspaceId={workspaceId}
+              reportId={reportId}
+              reportedSourceIds={reportedSourceIds}
+              riskReportBySourceId={riskReportBySourceId}
+              processedSourceIds={processedSourceIds}
+              onCancelReport={deleteMutation.mutate}
+              editable={editable}
+              allowReport={effectiveAllowReport}
+              pdfMode={pdfMode}
+            />
+          )}
         </div>
         {!hasArmor ? (
           <div className="print-keep flex flex-col gap-3">

--- a/src/components/report/highlight/Snapshot.tsx
+++ b/src/components/report/highlight/Snapshot.tsx
@@ -37,14 +37,20 @@ export function Snapshot({
 
   const period = isDaily ? '일간' : isInitial ? '월간' : '주간';
 
+  // 이번 기간 수집된 데이터가 0건이면 SIR 점수가 직전 일자 carry. 변화량 0 으로
+  // "전일 대비 유지" 가 표시되지만, 사용자에겐 "원래 데이터가 없어 점수가 멈춤" 이 더 정확.
+  const isNoData = totalItems === 0;
+
   const sirCard = {
     title: `${period} SIR 지수`,
     mobileTitle: `${period} SIR 지수`,
     description: '1,000점 만점 기준',
     value: `${Math.round(score)}점`,
-    change: snapshotDiff
-      ? formatChange(snapshotDiff.scoreDiff, '점', '상승', '하락', prefix)
-      : undefined,
+    change: isNoData
+      ? { label: '변동 없음', type: 'neutral' as const }
+      : snapshotDiff
+        ? formatChange(snapshotDiff.scoreDiff, '점', '상승', '하락', prefix)
+        : undefined,
   };
 
   const itemsCard = {
@@ -52,9 +58,11 @@ export function Snapshot({
     mobileTitle: `${period} 수집된\n평판 데이터 수`,
     description: '뉴스, 영상, 게시글 수집',
     value: `${totalItems.toLocaleString()}개`,
-    change: snapshotDiff
-      ? formatChange(snapshotDiff.itemsDiff, '개', '증가', '감소', prefix)
-      : undefined,
+    change: isNoData
+      ? { label: '수집된 데이터 없음', type: 'neutral' as const }
+      : snapshotDiff
+        ? formatChange(snapshotDiff.itemsDiff, '개', '증가', '감소', prefix)
+        : undefined,
   };
 
   const riskCard = {
@@ -62,9 +70,11 @@ export function Snapshot({
     mobileTitle: `${period} 수집된\n리스크 콘텐츠 수`,
     description: '즉시 검토 권장',
     value: `${riskCount.toLocaleString()}개`,
-    change: snapshotDiff
-      ? formatChange(snapshotDiff.riskDiff, '개', '증가', '감소', prefix, true)
-      : undefined,
+    change: isNoData
+      ? { label: '분석할 데이터 없음', type: 'neutral' as const }
+      : snapshotDiff
+        ? formatChange(snapshotDiff.riskDiff, '개', '증가', '감소', prefix, true)
+        : undefined,
   };
 
   // SIR 순위는 전체 기업 풀 비교 — daily 는 구독사가 제한적이라 모집단이 불완전해서 제외

--- a/src/components/report/reputation/ChannelVolumePanel.tsx
+++ b/src/components/report/reputation/ChannelVolumePanel.tsx
@@ -22,12 +22,21 @@ export function ChannelVolumePanel({ channelStats, pdfMode }: ChannelVolumePanel
     >
       <div className="flex flex-col lg:flex-row gap-4">
         <ReportCard className="lg:flex-1" px={20} py={20}>
-          <div className="hidden lg:block">
-            <ChannelDonutChart channelStats={channelStats} total={total} pdfMode={pdfMode} />
-          </div>
-          <div className="lg:hidden">
-            <MobileChannelDonutChart channelStats={channelStats} total={total} />
-          </div>
+          {total === 0 ? (
+            <div className="h-48 lg:h-60 flex flex-col items-center justify-center gap-2 text-center">
+              <span className="text-sm font-semibold text-text-muted">이번 기간 수집된 데이터가 없습니다.</span>
+              <span className="text-xs text-text-muted">채널별 비중을 계산할 데이터가 없습니다.</span>
+            </div>
+          ) : (
+            <>
+              <div className="hidden lg:block">
+                <ChannelDonutChart channelStats={channelStats} total={total} pdfMode={pdfMode} />
+              </div>
+              <div className="lg:hidden">
+                <MobileChannelDonutChart channelStats={channelStats} total={total} />
+              </div>
+            </>
+          )}
         </ReportCard>
 
         <div className="grid grid-cols-2 gap-3 lg:flex-1">

--- a/src/components/report/reputation/SentimentPanel.tsx
+++ b/src/components/report/reputation/SentimentPanel.tsx
@@ -32,6 +32,7 @@ export function SentimentPanel({ channelStats, pdfMode }: SentimentPanelProps) {
   const totalPositive = channelStats.reduce((s, c) => s + c.positive, 0);
   const totalNeutral = channelStats.reduce((s, c) => s + c.neutral, 0);
   const totalNegative = channelStats.reduce((s, c) => s + c.negative, 0);
+  const totalAll = totalPositive + totalNeutral + totalNegative;
 
   const CARD_ITEMS = [
     {
@@ -69,12 +70,21 @@ export function SentimentPanel({ channelStats, pdfMode }: SentimentPanelProps) {
           ))}
         </div>
         <ReportCard className="flex-1" px={20} py={20}>
-          <div className="hidden lg:block">
-            <SentimentStackedBar data={sentimentData} pdfMode={pdfMode} />
-          </div>
-          <div className="lg:hidden">
-            <MobileSentimentStackedBar data={sentimentData} />
-          </div>
+          {totalAll === 0 ? (
+            <div className="h-48 lg:h-80 flex flex-col items-center justify-center gap-2 text-center">
+              <span className="text-sm font-semibold text-text-muted">이번 기간 수집된 데이터가 없습니다.</span>
+              <span className="text-xs text-text-muted">긍정·중립·부정을 나눌 콘텐츠가 없습니다.</span>
+            </div>
+          ) : (
+            <>
+              <div className="hidden lg:block">
+                <SentimentStackedBar data={sentimentData} pdfMode={pdfMode} />
+              </div>
+              <div className="lg:hidden">
+                <MobileSentimentStackedBar data={sentimentData} />
+              </div>
+            </>
+          )}
         </ReportCard>
       </div>
     </ReportSubSection>

--- a/src/components/report/reputation/SirCard.tsx
+++ b/src/components/report/reputation/SirCard.tsx
@@ -70,6 +70,9 @@ export function SirCard({
   isDaily?: boolean;
   prevSir?: number;
 }) {
+  // 그 기간 그 채널 수집 0건 = 직전 일자 점수 그대로 표시.
+  // 사용자에게 명시적으로 알리지 않으면 실측처럼 보여 오해 위험.
+  const isNoData = stat.value === 0;
   const hasPrev = prevSir != null;
   const prevScore = prevSir ?? 500;
   const change = stat.sir - prevScore;
@@ -89,8 +92,15 @@ export function SirCard({
 
   return (
     <ReportCard px={20} py={20}>
-      <div className="flex flex-col gap-5">
-        <span className="text-sm font-semibold text-text-muted">{stat.label}</span>
+      <div className={`flex flex-col gap-5 ${isNoData ? 'opacity-60' : ''}`}>
+        <div className="flex items-center justify-between gap-2">
+          <span className="text-sm font-semibold text-text-muted">{stat.label}</span>
+          {isNoData && (
+            <span className="text-[10px] font-semibold text-amber-700 bg-amber-50 border border-amber-200 px-1.5 py-0.5 rounded">
+              데이터 없음
+            </span>
+          )}
+        </div>
         <div className="flex flex-col items-center gap-2 lg:gap-4 lg:mb-4">
           <div
             className={`w-9 h-9 lg:w-12 lg:h-12 rounded-full flex items-center justify-center ${config.bgClass}`}
@@ -105,30 +115,44 @@ export function SirCard({
           </div>
           <div className="flex flex-col justify-center items-center gap-2">
             <span className={`text-2xl font-bold ${config.textClass}`}>{stat.sir}점</span>
-            <span className="text-xs text-text-muted font-base whitespace-pre-line text-center lg:hidden">
-              {mobileLabel}
-            </span>
-            <span className="text-xs text-text-muted font-base hidden lg:block">{label}</span>
+            {isNoData ? (
+              <span className="text-[11px] text-text-muted font-normal text-center">
+                이번 기간 수집 0건
+              </span>
+            ) : (
+              <>
+                <span className="text-xs text-text-muted font-base whitespace-pre-line text-center lg:hidden">
+                  {mobileLabel}
+                </span>
+                <span className="text-xs text-text-muted font-base hidden lg:block">{label}</span>
+              </>
+            )}
           </div>
         </div>
-        <div
-          className={`flex flex-wrap items-center justify-center gap-x-1 text-[10px] lg:text-xs font-semibold w-full rounded-md py-2 ${
-            change === 0
-              ? 'bg-bg-light text-text-muted'
-              : isUp
-                ? 'bg-bg-blue text-text-accent'
-                : 'bg-bg-danger text-text-danger'
-          }`}
-        >
-          {change === 0 ? (
-            <span>{changeLabel} — 유지</span>
-          ) : (
-            <>
-              <span>{changeLabel}</span>
-              <span>{isUp ? '▲' : '▼'} {Math.abs(change)}점 {isUp ? '상승' : '하락'}</span>
-            </>
-          )}
-        </div>
+        {isNoData ? (
+          <div className="flex items-center justify-center gap-x-1 text-[10px] lg:text-xs font-semibold w-full rounded-md py-2 bg-bg-light text-text-muted">
+            변동 없음
+          </div>
+        ) : (
+          <div
+            className={`flex flex-wrap items-center justify-center gap-x-1 text-[10px] lg:text-xs font-semibold w-full rounded-md py-2 ${
+              change === 0
+                ? 'bg-bg-light text-text-muted'
+                : isUp
+                  ? 'bg-bg-blue text-text-accent'
+                  : 'bg-bg-danger text-text-danger'
+            }`}
+          >
+            {change === 0 ? (
+              <span>{changeLabel} — 유지</span>
+            ) : (
+              <>
+                <span>{changeLabel}</span>
+                <span>{isUp ? '▲' : '▼'} {Math.abs(change)}점 {isUp ? '상승' : '하락'}</span>
+              </>
+            )}
+          </div>
+        )}
       </div>
     </ReportCard>
   );

--- a/src/lib/api/reportApi.ts
+++ b/src/lib/api/reportApi.ts
@@ -433,8 +433,9 @@ export async function getChannelStats(
   periodStart?: string,
   periodEnd?: string,
 ): Promise<ChannelStat[]> {
-  // channelItems가 이미 report-scoped이므로 비어있으면 빈 stats 반환
-  if (channelItems.length === 0 && reportId) return [];
+  // channelItems 가 비어 있어도 4채널 placeholder stat 을 반환해야 SirCard 가 렌더됨
+  // (이전: return [] 로 차트/카드 통째로 사라짐 — 5/4 SB성보 같은 전체 0건 케이스에서 빈 화면)
+  // SirCard 의 stat.value === 0 분기가 amber 배지 + "직전 일자 기준" 표시로 빈 상태 명시.
 
   // 채널별 감정 집계 (positive/negative/neutral count)
   const byChannel = new Map<string, { positive: number; negative: number; neutral: number }>();


### PR DESCRIPTION
핵심 버그 fix:
- getChannelStats 가 channelItems 빈 배열일 때 stats=[] 반환 → SirCard 4개 자체가 렌더 안 되던 문제. 4채널 placeholder stat 반환으로 변경 (value=0, sir=carry)
- ChartCanvas / ReportSubSection 의 className 이 undefined 일 때 DOM 에 className="undefined" 박히던 prop 전파 버그 fix

0건 케이스 UI/UX (totalItems=0 또는 stat.value=0 일 때):
- Highlight 섹션 위에 amber 배너 — "이번 기간 수집된 데이터가 없습니다." 한눈 인지
- Snapshot 카드 3개 분기 — "변동 없음" / "수집된 데이터 없음" / "분석할 데이터 없음"
- SirCard 채널별 0건 — amber "데이터 없음" 배지 + "이번 기간 수집 0건" + "변동 없음"
- ChannelVolumePanel / SentimentPanel — 차트 자리에 안내 메시지로 대체
- RiskContent — channelItems=0 일 때 "리스크 0건" 메시지 대신 "분석 보류" 명시 ("리스크 0건" vs "수집 0건" 의미 혼동 방지)

