### PR TITLE
feat(front): 사용자 모니터링 페이지 신설 (실데이터 + 날짜 직접 선택)

### DIFF
--- a/src/app/(client)/monitoring/[workspaceId]/page.tsx
+++ b/src/app/(client)/monitoring/[workspaceId]/page.tsx
@@ -1,0 +1,915 @@
+'use client';
+
+import { useMemo, useState } from 'react';
+import { useParams } from 'next/navigation';
+import {
+  ComposedChart,
+  AreaChart,
+  BarChart,
+  Line,
+  Bar,
+  Area,
+  XAxis,
+  YAxis,
+  CartesianGrid,
+  Tooltip,
+} from 'recharts';
+import {
+  AlertTriangle,
+  TrendingUp,
+  TrendingDown,
+  Minus,
+  Activity,
+  MessageSquare,
+  Calendar,
+} from 'lucide-react';
+import { useWorkspace } from '@/hooks/workspace/useWorkspaceQuery';
+import {
+  useMonitoringDaily,
+  useMonitoringStock,
+  useMonitoringRisks,
+} from '@/hooks/monitoring/useMonitoringQuery';
+import {
+  MONITORING_CHANNELS,
+  CRITICAL_TYPES,
+  type Channel,
+  type CriticalType,
+  type MonitoringDayPoint,
+} from '@/lib/api/monitoringApi';
+import { ChartCanvas } from '@/components/chart/ChartCanvas';
+
+// ── color tokens ────────────────────────────────────────────────────────
+const CHANNEL_COLOR: Record<Channel, string> = {
+  news: '#2563eb',
+  blog: '#10b981',
+  youtube: '#ef4444',
+  community: '#f59e0b',
+};
+const CRITICAL_COLOR: Record<CriticalType, string> = {
+  defamation: '#7c3aed',
+  insult: '#ec4899',
+  rumor: '#f97316',
+  spam: '#0ea5e9',
+};
+const SENTIMENT_COLOR = { pos: '#10b981', neu: '#94a3b8', neg: '#ef4444' };
+const PRIMARY = '#2563eb';
+const PRIMARY_SOFT = 'rgba(37, 99, 235, 0.08)';
+
+// ── date utils (KST 기준) ──────────────────────────────────────────────
+
+function kstTodayStr(): string {
+  const kst = new Date(Date.now() + 9 * 60 * 60 * 1000);
+  return kst.toISOString().slice(0, 10);
+}
+
+function shiftDays(dateStr: string, days: number): string {
+  const d = new Date(`${dateStr}T00:00:00+09:00`);
+  d.setUTCDate(d.getUTCDate() + days);
+  const kst = new Date(d.getTime() + 9 * 60 * 60 * 1000);
+  return kst.toISOString().slice(0, 10);
+}
+
+function diffDays(start: string, end: string): number {
+  const s = new Date(`${start}T00:00:00+09:00`).getTime();
+  const e = new Date(`${end}T00:00:00+09:00`).getTime();
+  return Math.round((e - s) / (24 * 60 * 60 * 1000)) + 1;
+}
+
+function shortDate(s: string): string {
+  if (!s || s.length < 10) return s;
+  return `${parseInt(s.slice(5, 7), 10)}/${parseInt(s.slice(8, 10), 10)}`;
+}
+
+const PRESETS = [
+  { id: 7, label: '7일' },
+  { id: 30, label: '30일' },
+  { id: 90, label: '90일' },
+  { id: 180, label: '180일' },
+  { id: 365, label: '1년' },
+] as const;
+
+// ── PAGE ────────────────────────────────────────────────────────────────
+
+export default function MonitoringPage() {
+  const params = useParams();
+  const workspaceId = (params?.workspaceId as string) ?? '';
+  const { data: workspace } = useWorkspace(workspaceId);
+
+  const today = useMemo(() => kstTodayStr(), []);
+  const [start, setStart] = useState(() => shiftDays(today, -89));
+  const [end, setEnd] = useState(today);
+
+  // 직전 동기간 — KPI 비교용
+  const range = diffDays(start, end);
+  const prevEnd = shiftDays(start, -1);
+  const prevStart = shiftDays(prevEnd, -(range - 1));
+
+  const { data: daily = [], isPending: dailyLoading } = useMonitoringDaily(workspaceId, start, end);
+  const { data: stock = [], isPending: stockLoading } = useMonitoringStock(workspaceId, start, end);
+  const { data: risks = [], isPending: risksLoading } = useMonitoringRisks(workspaceId, start, end);
+
+  const { data: prevDaily = [] } = useMonitoringDaily(workspaceId, prevStart, prevEnd);
+  const { data: prevRisks = [] } = useMonitoringRisks(workspaceId, prevStart, prevEnd);
+
+  const isLoading = dailyLoading || stockLoading || risksLoading;
+
+  // ── 머지: 전체 일자 축 (수집/주가/리스크 모두 한 series 안에 두면 차트 정렬 안정) ──
+  type MergedPoint = MonitoringDayPoint & {
+    open: number | null;
+    high: number | null;
+    low: number | null;
+    close: number | null;
+    risks: Record<CriticalType, number>;
+    riskTotal: number;
+  };
+
+  const merged: MergedPoint[] = useMemo(() => {
+    const dailyMap = new Map(daily.map((d) => [d.date, d]));
+    const stockMap = new Map(stock.map((d) => [d.date, d]));
+    const riskMap = new Map(risks.map((d) => [d.date, d]));
+    const allDates = new Set<string>([
+      ...daily.map((d) => d.date),
+      ...stock.map((d) => d.date),
+      ...risks.map((d) => d.date),
+    ]);
+    return Array.from(allDates)
+      .sort()
+      .map((date) => {
+        const d = dailyMap.get(date);
+        const s = stockMap.get(date);
+        const r = riskMap.get(date);
+        return {
+          date,
+          isCarried: d?.isCarried ?? false,
+          channelVolume: d?.channelVolume ?? { news: 0, blog: 0, youtube: 0, community: 0 },
+          totalVolume: d?.totalVolume ?? 0,
+          positive: d?.positive ?? 0,
+          neutral: d?.neutral ?? 0,
+          negative: d?.negative ?? 0,
+          open: s?.open ?? null,
+          high: s?.high ?? null,
+          low: s?.low ?? null,
+          close: s?.close ?? null,
+          risks: r?.byType ?? { defamation: 0, insult: 0, rumor: 0, spam: 0 },
+          riskTotal: r?.total ?? 0,
+        };
+      });
+  }, [daily, stock, risks]);
+
+  // ── KPI ─────────────────────────────────────────────────────────────
+  const kpi = useMemo(() => {
+    const totalVol = daily.reduce((s, d) => s + d.totalVolume, 0);
+    const prevVol = prevDaily.reduce((s, d) => s + d.totalVolume, 0);
+    const volDelta = totalVol - prevVol;
+
+    const totalNeg = daily.reduce((s, d) => s + d.negative, 0);
+    const totalAll = daily.reduce((s, d) => s + d.positive + d.neutral + d.negative, 0);
+    const negPct = totalAll > 0 ? Math.round((totalNeg / totalAll) * 100) : 0;
+    const prevNeg = prevDaily.reduce((s, d) => s + d.negative, 0);
+    const prevAll = prevDaily.reduce((s, d) => s + d.positive + d.neutral + d.negative, 0);
+    const prevNegPct = prevAll > 0 ? Math.round((prevNeg / prevAll) * 100) : 0;
+    const negDelta = negPct - prevNegPct;
+
+    const totalRisks = risks.reduce((s, d) => s + d.total, 0);
+    const prevTotalRisks = prevRisks.reduce((s, d) => s + d.total, 0);
+    const riskDelta = totalRisks - prevTotalRisks;
+
+    const stockSorted = stock.filter((s) => s.close != null);
+    const lastClose = stockSorted[stockSorted.length - 1]?.close ?? null;
+    const firstClose = stockSorted[0]?.close ?? null;
+    const priceDeltaPct =
+      firstClose && lastClose ? ((lastClose - firstClose) / firstClose) * 100 : null;
+
+    return {
+      totalVol,
+      volDelta,
+      negPct,
+      negDelta,
+      totalRisks,
+      riskDelta,
+      lastClose,
+      priceDeltaPct,
+    };
+  }, [daily, prevDaily, risks, prevRisks, stock]);
+
+  // ── 감정 비율 시계열 (스택 area 용) ────────────────────────────────
+  // pos/neg 를 독립 반올림하면 합이 99~101 이 될 수 있어 Y축이 101% 까지 늘어나므로,
+  // pos·neg 만 round 하고 neutral 은 차감으로 산정해 합 = 100 보장.
+  const sentimentSeries = useMemo(
+    () =>
+      merged.map((d) => {
+        const t = d.positive + d.neutral + d.negative;
+        if (!t) return { date: d.date, positive: 0, neutral: 0, negative: 0, totalVolume: 0 };
+        let pos = Math.round((d.positive / t) * 100);
+        let neg = Math.round((d.negative / t) * 100);
+        if (pos + neg > 100) {
+          if (pos >= neg) pos = 100 - neg;
+          else neg = 100 - pos;
+        }
+        const neu = 100 - pos - neg;
+        return { date: d.date, positive: pos, neutral: neu, negative: neg, totalVolume: t };
+      }),
+    [merged],
+  );
+
+  const handlePreset = (days: number) => {
+    setEnd(today);
+    setStart(shiftDays(today, -(days - 1)));
+  };
+
+  return (
+    <div className="h-full bg-white overflow-y-auto">
+      <div className="mx-auto w-full max-w-[1240px] px-4 lg:px-10 py-7 lg:py-10 flex flex-col gap-7">
+
+        {/* 헤더 ─────────────────────────────────────────── */}
+        <header className="flex flex-col gap-1.5">
+          <div className="flex items-center gap-2 text-xs text-slate-400 font-medium">
+            <Activity size={13} className="text-slate-300" />
+            <span>SIR · Monitoring</span>
+          </div>
+          <h1 className="text-[26px] lg:text-[28px] font-bold tracking-[-0.02em] text-slate-900 leading-[1.2]">
+            {workspace?.company_name ?? '워크스페이스'} 모니터링
+          </h1>
+          <p className="text-[13px] text-slate-500 leading-[1.6] max-w-[860px]">
+            일자별 누적 데이터 기반 시계열 추이입니다. 좌측 날짜를 직접 선택하거나 우측 프리셋을 눌러 기간을 바꿀 수 있고,
+            모든 KPI 는 같은 길이의 직전 기간과 비교해 보여줍니다.
+          </p>
+        </header>
+
+        {/* 날짜 선택 + 프리셋 ───────────────────────────── */}
+        <div className="rounded-2xl bg-slate-50/70 border border-slate-200/80 px-4 lg:px-5 py-4 flex flex-col lg:flex-row lg:items-center gap-4 lg:gap-6">
+          <div className="flex items-center gap-2 text-slate-400">
+            <Calendar size={15} />
+            <span className="text-[11px] font-bold tracking-[0.08em] uppercase">기간</span>
+          </div>
+          <div className="flex items-center gap-2.5 flex-wrap">
+            <DateInput value={start} max={end} onChange={setStart} aria-label="시작일" />
+            <span className="text-slate-300">—</span>
+            <DateInput value={end} min={start} max={today} onChange={setEnd} aria-label="종료일" />
+            <span className="text-[11px] text-slate-400 tabular-nums ml-1">{range}일</span>
+          </div>
+          <div className="flex items-center gap-1 lg:ml-auto flex-wrap">
+            {PRESETS.map((p) => {
+              const active = range === p.id && end === today;
+              return (
+                <button
+                  key={p.id}
+                  type="button"
+                  onClick={() => handlePreset(p.id)}
+                  className={`text-[11px] font-bold px-3 py-1.5 rounded-full border transition-colors cursor-pointer tracking-[-0.005em] ${
+                    active
+                      ? 'bg-slate-900 text-white border-slate-900'
+                      : 'bg-white text-slate-500 border-slate-200 hover:border-slate-300 hover:text-slate-700'
+                  }`}
+                >
+                  {p.label}
+                </button>
+              );
+            })}
+          </div>
+        </div>
+
+        {/* KPI ───────────────────────────────────────────── */}
+        <div className="grid grid-cols-2 lg:grid-cols-4 gap-3.5">
+          <KpiCard
+            icon={<MessageSquare size={14} />}
+            label="총 수집량"
+            value={kpi.totalVol.toLocaleString()}
+            unit="건"
+            delta={kpi.volDelta}
+            tone="default"
+            sub={`직전 ${range}일 대비`}
+            loading={isLoading}
+          />
+          <KpiCard
+            icon={<Activity size={14} />}
+            label="현재 주가"
+            value={kpi.lastClose != null ? kpi.lastClose.toLocaleString() : '—'}
+            unit="원"
+            deltaText={
+              kpi.priceDeltaPct == null
+                ? null
+                : `${kpi.priceDeltaPct >= 0 ? '+' : ''}${kpi.priceDeltaPct.toFixed(2)}%`
+            }
+            deltaTone={kpi.priceDeltaPct == null ? 'neutral' : kpi.priceDeltaPct >= 0 ? 'up' : 'down'}
+            sub={`기간 시작 대비`}
+            loading={isLoading}
+          />
+          <KpiCard
+            icon={<TrendingDown size={14} />}
+            label="부정 여론"
+            value={kpi.negPct.toString()}
+            unit="%"
+            delta={kpi.negDelta}
+            deltaSuffix="%p"
+            invertDeltaTone
+            tone={kpi.negPct >= 30 ? 'danger' : 'default'}
+            sub={`직전 ${range}일 대비`}
+            loading={isLoading}
+          />
+          <KpiCard
+            icon={<AlertTriangle size={14} />}
+            label="리스크 콘텐츠"
+            value={kpi.totalRisks.toString()}
+            unit="건"
+            delta={kpi.riskDelta}
+            invertDeltaTone
+            tone={kpi.totalRisks > 0 ? 'warn' : 'default'}
+            sub={`직전 ${range}일 대비`}
+            loading={isLoading}
+          />
+        </div>
+
+        {/* 차트 그리드 ────────────────────────────────── */}
+        <div className="grid grid-cols-1 lg:grid-cols-2 gap-4">
+          {/* 주가 + 수집량 — full width hero */}
+          <div className="lg:col-span-2">
+            <ChartCard
+              title="주가와 수집량"
+              subtitle="시장 가격 신호와 여론 양의 동조·괴리"
+              loading={isLoading}
+              empty={merged.length === 0}
+            >
+              <div className="h-[300px]">
+                <ChartCanvas>
+                  <ComposedChart data={merged} margin={{ top: 12, right: 18, bottom: 0, left: 0 }}>
+                    <defs>
+                      <linearGradient id="volBar" x1="0" y1="0" x2="0" y2="1">
+                        <stop offset="0%" stopColor={PRIMARY} stopOpacity={0.5} />
+                        <stop offset="100%" stopColor={PRIMARY} stopOpacity={0.1} />
+                      </linearGradient>
+                    </defs>
+                    <CartesianGrid strokeDasharray="3 3" stroke="#f1f5f9" vertical={false} />
+                    <XAxis
+                      dataKey="date"
+                      tickFormatter={shortDate}
+                      tick={{ fontSize: 10, fill: '#94a3b8' }}
+                      axisLine={{ stroke: '#e2e8f0' }}
+                      tickLine={false}
+                      interval="preserveStartEnd"
+                      minTickGap={32}
+                    />
+                    <YAxis
+                      yAxisId="vol"
+                      orientation="left"
+                      tick={{ fontSize: 10, fill: '#94a3b8' }}
+                      axisLine={false}
+                      tickLine={false}
+                      width={36}
+                    />
+                    <YAxis
+                      yAxisId="price"
+                      orientation="right"
+                      tickFormatter={(v) => (v >= 10000 ? `${Math.round(v / 1000)}k` : v.toLocaleString())}
+                      tick={{ fontSize: 10, fill: '#94a3b8' }}
+                      axisLine={false}
+                      tickLine={false}
+                      width={48}
+                      domain={['auto', 'auto']}
+                    />
+                    <Tooltip cursor={{ fill: PRIMARY_SOFT }} content={<PriceVolumeTooltip />} />
+                    <Bar
+                      yAxisId="vol"
+                      dataKey="totalVolume"
+                      name="수집량"
+                      fill="url(#volBar)"
+                      isAnimationActive={false}
+                      barSize={range >= 180 ? 2 : range >= 90 ? 4 : 8}
+                    />
+                    <Line
+                      yAxisId="price"
+                      type="monotone"
+                      dataKey="close"
+                      name="종가"
+                      stroke="#0f172a"
+                      strokeWidth={2}
+                      dot={false}
+                      isAnimationActive={false}
+                      connectNulls
+                    />
+                  </ComposedChart>
+                </ChartCanvas>
+              </div>
+              <ChartLegend
+                items={[
+                  { color: PRIMARY, label: '수집량 (좌, 건)', soft: true },
+                  { color: '#0f172a', label: '주가 종가 (우, 원)' },
+                ]}
+              />
+            </ChartCard>
+          </div>
+
+          {/* 감정 분포 */}
+          <ChartCard
+            title="감정 분포 추이"
+            subtitle="긍정 · 중립 · 부정 비중"
+            loading={isLoading}
+            empty={sentimentSeries.every((d) => d.totalVolume === 0)}
+          >
+            <div className="h-[260px]">
+              <ChartCanvas>
+                <AreaChart data={sentimentSeries} margin={{ top: 12, right: 16, bottom: 0, left: 0 }}>
+                  <defs>
+                    <linearGradient id="gPos" x1="0" y1="0" x2="0" y2="1">
+                      <stop offset="0%" stopColor={SENTIMENT_COLOR.pos} stopOpacity={0.45} />
+                      <stop offset="100%" stopColor={SENTIMENT_COLOR.pos} stopOpacity={0.1} />
+                    </linearGradient>
+                    <linearGradient id="gNeu" x1="0" y1="0" x2="0" y2="1">
+                      <stop offset="0%" stopColor={SENTIMENT_COLOR.neu} stopOpacity={0.4} />
+                      <stop offset="100%" stopColor={SENTIMENT_COLOR.neu} stopOpacity={0.08} />
+                    </linearGradient>
+                    <linearGradient id="gNeg" x1="0" y1="0" x2="0" y2="1">
+                      <stop offset="0%" stopColor={SENTIMENT_COLOR.neg} stopOpacity={0.45} />
+                      <stop offset="100%" stopColor={SENTIMENT_COLOR.neg} stopOpacity={0.1} />
+                    </linearGradient>
+                  </defs>
+                  <CartesianGrid strokeDasharray="3 3" stroke="#f1f5f9" vertical={false} />
+                  <XAxis
+                    dataKey="date"
+                    tickFormatter={shortDate}
+                    tick={{ fontSize: 10, fill: '#94a3b8' }}
+                    axisLine={{ stroke: '#e2e8f0' }}
+                    tickLine={false}
+                    interval="preserveStartEnd"
+                    minTickGap={32}
+                  />
+                  <YAxis
+                    domain={[0, 100]}
+                    ticks={[0, 25, 50, 75, 100]}
+                    allowDataOverflow
+                    tickFormatter={(v) => `${v}%`}
+                    tick={{ fontSize: 10, fill: '#94a3b8' }}
+                    axisLine={false}
+                    tickLine={false}
+                    width={36}
+                  />
+                  <Tooltip cursor={{ fill: PRIMARY_SOFT }} content={<PercentTooltip />} />
+                  <Area type="monotone" dataKey="positive" name="긍정" stackId="s" stroke={SENTIMENT_COLOR.pos} strokeWidth={1.4} fill="url(#gPos)" isAnimationActive={false} />
+                  <Area type="monotone" dataKey="neutral" name="중립" stackId="s" stroke={SENTIMENT_COLOR.neu} strokeWidth={1.4} fill="url(#gNeu)" isAnimationActive={false} />
+                  <Area type="monotone" dataKey="negative" name="부정" stackId="s" stroke={SENTIMENT_COLOR.neg} strokeWidth={1.4} fill="url(#gNeg)" isAnimationActive={false} />
+                </AreaChart>
+              </ChartCanvas>
+            </div>
+            <ChartLegend
+              items={[
+                { color: SENTIMENT_COLOR.pos, label: '긍정' },
+                { color: SENTIMENT_COLOR.neu, label: '중립' },
+                { color: SENTIMENT_COLOR.neg, label: '부정' },
+              ]}
+            />
+          </ChartCard>
+
+          {/* 리스크 발생 */}
+          <ChartCard
+            title="리스크 발생"
+            subtitle="critical_type 별 일자 건수"
+            loading={isLoading}
+            empty={merged.every((d) => d.riskTotal === 0)}
+          >
+            <div className="h-[260px]">
+              <ChartCanvas>
+                <BarChart data={merged} margin={{ top: 12, right: 16, bottom: 0, left: 0 }}>
+                  <CartesianGrid strokeDasharray="3 3" stroke="#f1f5f9" vertical={false} />
+                  <XAxis
+                    dataKey="date"
+                    tickFormatter={shortDate}
+                    tick={{ fontSize: 10, fill: '#94a3b8' }}
+                    axisLine={{ stroke: '#e2e8f0' }}
+                    tickLine={false}
+                    interval="preserveStartEnd"
+                    minTickGap={32}
+                  />
+                  <YAxis
+                    tick={{ fontSize: 10, fill: '#94a3b8' }}
+                    axisLine={false}
+                    tickLine={false}
+                    width={28}
+                    allowDecimals={false}
+                  />
+                  <Tooltip cursor={{ fill: 'rgba(239, 68, 68, 0.06)' }} content={<RiskTooltip />} />
+                  {CRITICAL_TYPES.map((c) => (
+                    <Bar
+                      key={c.id}
+                      dataKey={(d: MergedPoint) => d.risks[c.id] ?? 0}
+                      name={c.label}
+                      stackId="risk"
+                      fill={CRITICAL_COLOR[c.id]}
+                      isAnimationActive={false}
+                      barSize={range >= 180 ? 2 : range >= 90 ? 4 : 8}
+                    />
+                  ))}
+                </BarChart>
+              </ChartCanvas>
+            </div>
+            <ChartLegend
+              items={CRITICAL_TYPES.map((c) => ({ color: CRITICAL_COLOR[c.id], label: c.label }))}
+            />
+          </ChartCard>
+
+          {/* 채널별 수집량 — full width */}
+          <div className="lg:col-span-2">
+            <ChartCard
+              title="채널별 수집량"
+              subtitle="뉴스 · 블로그 · 유튜브 · 커뮤니티 일자 누적"
+              loading={isLoading}
+              empty={merged.every((d) => d.totalVolume === 0)}
+            >
+              <div className="h-[260px]">
+                <ChartCanvas>
+                  <BarChart data={merged} margin={{ top: 12, right: 16, bottom: 0, left: 0 }}>
+                    <CartesianGrid strokeDasharray="3 3" stroke="#f1f5f9" vertical={false} />
+                    <XAxis
+                      dataKey="date"
+                      tickFormatter={shortDate}
+                      tick={{ fontSize: 10, fill: '#94a3b8' }}
+                      axisLine={{ stroke: '#e2e8f0' }}
+                      tickLine={false}
+                      interval="preserveStartEnd"
+                      minTickGap={32}
+                    />
+                    <YAxis
+                      tick={{ fontSize: 10, fill: '#94a3b8' }}
+                      axisLine={false}
+                      tickLine={false}
+                      width={28}
+                    />
+                    <Tooltip cursor={{ fill: PRIMARY_SOFT }} content={<VolumeTooltip />} />
+                    {MONITORING_CHANNELS.map((c) => (
+                      <Bar
+                        key={c.id}
+                        dataKey={(d: MergedPoint) => d.channelVolume[c.id]}
+                        name={c.label}
+                        stackId="vol"
+                        fill={CHANNEL_COLOR[c.id]}
+                        isAnimationActive={false}
+                        barSize={range >= 180 ? 2 : range >= 90 ? 4 : 8}
+                      />
+                    ))}
+                  </BarChart>
+                </ChartCanvas>
+              </div>
+              <ChartLegend
+                items={MONITORING_CHANNELS.map((c) => ({ color: CHANNEL_COLOR[c.id], label: c.label }))}
+              />
+            </ChartCard>
+          </div>
+        </div>
+
+      </div>
+    </div>
+  );
+}
+
+// ── shared subcomponents ────────────────────────────────────────────────
+
+function DateInput({
+  value,
+  onChange,
+  min,
+  max,
+  ...rest
+}: {
+  value: string;
+  onChange: (v: string) => void;
+  min?: string;
+  max?: string;
+} & Omit<React.InputHTMLAttributes<HTMLInputElement>, 'value' | 'onChange' | 'min' | 'max' | 'type'>) {
+  return (
+    <input
+      type="date"
+      value={value}
+      min={min}
+      max={max}
+      onChange={(e) => {
+        if (!e.target.value) return;
+        onChange(e.target.value);
+      }}
+      className="text-[12px] font-semibold text-slate-700 bg-white border border-slate-200 rounded-lg px-2.5 py-1.5 outline-none focus:border-slate-400 focus:ring-2 focus:ring-slate-100 transition-all tabular-nums cursor-pointer"
+      {...rest}
+    />
+  );
+}
+
+function KpiCard({
+  icon,
+  label,
+  value,
+  unit,
+  delta,
+  deltaText,
+  deltaSuffix,
+  deltaTone,
+  invertDeltaTone,
+  tone,
+  sub,
+  loading,
+}: {
+  icon: React.ReactNode;
+  label: string;
+  value: string;
+  unit?: string;
+  delta?: number;
+  deltaText?: string | null;
+  deltaSuffix?: string;
+  deltaTone?: 'up' | 'down' | 'neutral';
+  invertDeltaTone?: boolean;
+  tone?: 'default' | 'warn' | 'danger';
+  sub?: string;
+  loading?: boolean;
+}) {
+  const toneClass =
+    tone === 'warn'
+      ? 'border-amber-200/80 bg-gradient-to-br from-amber-50/60 to-white'
+      : tone === 'danger'
+        ? 'border-red-200/80 bg-gradient-to-br from-red-50/50 to-white'
+        : 'border-slate-200/80 bg-white';
+
+  // deltaTone 자동 결정 (delta 가 number 일 때)
+  let resolvedTone: 'up' | 'down' | 'neutral' = deltaTone ?? 'neutral';
+  if (delta !== undefined && deltaTone === undefined) {
+    if (delta > 0) resolvedTone = invertDeltaTone ? 'down' : 'up';
+    else if (delta < 0) resolvedTone = invertDeltaTone ? 'up' : 'down';
+  }
+
+  const deltaColor =
+    resolvedTone === 'up'
+      ? 'text-emerald-600'
+      : resolvedTone === 'down'
+        ? 'text-red-500'
+        : 'text-slate-400';
+
+  const renderedDelta =
+    deltaText !== undefined
+      ? deltaText
+      : delta !== undefined
+        ? delta === 0
+          ? '변동 없음'
+          : `${delta > 0 ? '+' : ''}${delta.toLocaleString()}${deltaSuffix ?? ''}`
+        : null;
+
+  return (
+    <div
+      className={`rounded-2xl border p-5 flex flex-col gap-2.5 min-h-[140px] ${toneClass} shadow-[0_1px_2px_rgba(15,23,42,0.04)]`}
+    >
+      <div className="flex items-center gap-2 text-slate-400">
+        <span>{icon}</span>
+        <span className="text-[11px] font-bold tracking-[0.06em] uppercase">{label}</span>
+      </div>
+      {loading ? (
+        <div className="h-10 w-24 bg-slate-100 rounded animate-pulse" />
+      ) : (
+        <div className="flex items-baseline gap-1">
+          <span className="text-[34px] font-bold tracking-[-0.025em] leading-[1] tabular-nums text-slate-900">
+            {value}
+          </span>
+          {unit && <span className="text-sm font-semibold text-slate-400">{unit}</span>}
+        </div>
+      )}
+      <div className="mt-auto flex flex-col gap-0.5">
+        {renderedDelta != null && !loading && (
+          <div className={`text-[12px] font-bold flex items-center gap-1 ${deltaColor}`}>
+            {resolvedTone === 'up' ? (
+              <TrendingUp size={11} />
+            ) : resolvedTone === 'down' ? (
+              <TrendingDown size={11} />
+            ) : (
+              <Minus size={11} />
+            )}
+            <span className="tabular-nums">{renderedDelta}</span>
+          </div>
+        )}
+        {sub && <div className="text-[11px] text-slate-400 font-medium">{sub}</div>}
+      </div>
+    </div>
+  );
+}
+
+function ChartCard({
+  title,
+  subtitle,
+  children,
+  loading,
+  empty,
+}: {
+  title: string;
+  subtitle?: string;
+  children: React.ReactNode;
+  loading?: boolean;
+  empty?: boolean;
+}) {
+  return (
+    <div className="rounded-2xl bg-white border border-slate-200/80 p-5 lg:p-6 flex flex-col gap-4 shadow-[0_1px_2px_rgba(15,23,42,0.04)]">
+      <div className="flex flex-col gap-0.5">
+        <h3 className="text-[14px] font-bold text-slate-900 tracking-[-0.005em] m-0">{title}</h3>
+        {subtitle && <p className="text-[11px] text-slate-400 m-0 leading-[1.55]">{subtitle}</p>}
+      </div>
+      {loading ? (
+        <div className="h-[260px] rounded-xl bg-slate-50 animate-pulse" />
+      ) : empty ? (
+        <div className="h-[260px] flex items-center justify-center text-[12px] text-slate-400">
+          이 기간에 표시할 데이터가 없습니다
+        </div>
+      ) : (
+        children
+      )}
+    </div>
+  );
+}
+
+function ChartLegend({ items }: { items: { color: string; label: string; soft?: boolean }[] }) {
+  return (
+    <div className="flex items-center gap-4 text-[11px] font-semibold text-slate-500 flex-wrap">
+      {items.map((it) => (
+        <div key={it.label} className="flex items-center gap-1.5">
+          <span
+            className="inline-block w-2.5 h-2.5 rounded-full"
+            style={{ background: it.color, opacity: it.soft ? 0.55 : 1 }}
+          />
+          <span>{it.label}</span>
+        </div>
+      ))}
+    </div>
+  );
+}
+
+// ── tooltips ────────────────────────────────────────────────────────────
+
+interface TipPayload {
+  name?: string;
+  value?: number;
+  color?: string;
+  payload?: {
+    isCarried?: boolean;
+    open?: number | null;
+    high?: number | null;
+    low?: number | null;
+    close?: number | null;
+    totalVolume?: number;
+    [k: string]: unknown;
+  };
+}
+
+function TooltipShell({ label, children }: { label?: string; children: React.ReactNode }) {
+  return (
+    <div className="bg-white/95 backdrop-blur border border-slate-200 rounded-xl px-3.5 py-3 shadow-[0_8px_24px_rgba(15,23,42,0.10)] min-w-[180px]">
+      <p className="text-[11px] font-bold tracking-[0.04em] text-slate-400 m-0 mb-2 tabular-nums">
+        {label?.replace(/-/g, '.')}
+      </p>
+      {children}
+    </div>
+  );
+}
+
+function TooltipRow({
+  color,
+  label,
+  value,
+  bold,
+}: {
+  color?: string;
+  label: string;
+  value: string;
+  bold?: boolean;
+}) {
+  return (
+    <div className="flex items-center gap-2.5 py-0.5">
+      {color && <span className="inline-block w-2 h-2 rounded-full shrink-0" style={{ background: color }} />}
+      <span className="text-[12px] text-slate-500">{label}</span>
+      <span
+        className={`ml-auto text-[12px] tabular-nums ${bold ? 'font-bold text-slate-900' : 'font-semibold text-slate-700'}`}
+      >
+        {value}
+      </span>
+    </div>
+  );
+}
+
+function PriceVolumeTooltip({
+  active,
+  payload,
+  label,
+}: {
+  active?: boolean;
+  payload?: TipPayload[];
+  label?: string;
+}) {
+  if (!active || !payload?.length) return null;
+  const d = payload[0]?.payload;
+  if (!d) return null;
+  const hasPrice = d.close != null && d.open != null;
+  const upDay = hasPrice && (d.close ?? 0) >= (d.open ?? 0);
+  return (
+    <TooltipShell label={label}>
+      {hasPrice ? (
+        <>
+          <TooltipRow color="#0f172a" label="종가" value={`${d.close!.toLocaleString()}원`} bold />
+          <div className="grid grid-cols-2 gap-x-3 mt-1 mb-1.5 text-[11px] text-slate-400">
+            <span>시 <span className="text-slate-700 font-semibold tabular-nums ml-1">{d.open!.toLocaleString()}</span></span>
+            {d.high != null && (
+              <span>고 <span className="text-slate-700 font-semibold tabular-nums ml-1">{d.high.toLocaleString()}</span></span>
+            )}
+            {d.low != null && (
+              <span>저 <span className="text-slate-700 font-semibold tabular-nums ml-1">{d.low.toLocaleString()}</span></span>
+            )}
+            <span className={upDay ? 'text-red-500' : 'text-blue-500'}>
+              {upDay ? '▲' : '▼'} {Math.abs((((d.close ?? 0) - (d.open ?? 0)) / (d.open ?? 1)) * 100).toFixed(2)}%
+            </span>
+          </div>
+        </>
+      ) : (
+        <div className="text-[12px] text-slate-400 mb-2">주가 데이터 없음</div>
+      )}
+      <div className="border-t border-slate-100 pt-2">
+        <TooltipRow color={PRIMARY} label="수집량" value={`${(d.totalVolume ?? 0).toLocaleString()}건`} />
+      </div>
+      {d.isCarried && (
+        <p className="text-[10px] text-amber-600 mt-1.5 font-semibold">⚠ 직전 일자 자동 보정</p>
+      )}
+    </TooltipShell>
+  );
+}
+
+function PercentTooltip({
+  active,
+  payload,
+  label,
+}: {
+  active?: boolean;
+  payload?: TipPayload[];
+  label?: string;
+}) {
+  if (!active || !payload?.length) return null;
+  const d = payload[0]?.payload;
+  if (!d || (d.totalVolume ?? 0) === 0) {
+    return (
+      <TooltipShell label={label}>
+        <div className="text-[12px] text-slate-400">분석 데이터 없음</div>
+      </TooltipShell>
+    );
+  }
+  return (
+    <TooltipShell label={label}>
+      {payload.map((p, i) => (
+        <TooltipRow key={i} color={p.color} label={p.name ?? ''} value={`${p.value}%`} />
+      ))}
+      <div className="border-t border-slate-100 mt-1.5 pt-1.5">
+        <TooltipRow label="전체" value={`${(d.totalVolume ?? 0).toLocaleString()}건`} bold />
+      </div>
+    </TooltipShell>
+  );
+}
+
+function VolumeTooltip({
+  active,
+  payload,
+  label,
+}: {
+  active?: boolean;
+  payload?: TipPayload[];
+  label?: string;
+}) {
+  if (!active || !payload?.length) return null;
+  const total = payload.reduce((s, p) => s + (p.value ?? 0), 0);
+  return (
+    <TooltipShell label={label}>
+      {payload.map((p, i) => (
+        <TooltipRow key={i} color={p.color} label={p.name ?? ''} value={`${(p.value ?? 0).toLocaleString()}건`} />
+      ))}
+      <div className="border-t border-slate-100 mt-1.5 pt-1.5">
+        <TooltipRow label="합계" value={`${total.toLocaleString()}건`} bold />
+      </div>
+    </TooltipShell>
+  );
+}
+
+function RiskTooltip({
+  active,
+  payload,
+  label,
+}: {
+  active?: boolean;
+  payload?: TipPayload[];
+  label?: string;
+}) {
+  if (!active || !payload?.length) return null;
+  const filtered = payload.filter((p) => (p.value ?? 0) > 0);
+  if (!filtered.length) {
+    return (
+      <TooltipShell label={label}>
+        <div className="text-[12px] text-slate-400">발생 없음</div>
+      </TooltipShell>
+    );
+  }
+  const total = filtered.reduce((s, p) => s + (p.value ?? 0), 0);
+  return (
+    <TooltipShell label={label}>
+      {filtered.map((p, i) => (
+        <TooltipRow key={i} color={p.color} label={p.name ?? ''} value={`${p.value}건`} />
+      ))}
+      <div className="border-t border-slate-100 mt-1.5 pt-1.5">
+        <TooltipRow label="합계" value={`${total}건`} bold />
+      </div>
+    </TooltipShell>
+  );
+}
+

--- a/src/components/client/sidebar/SidebarMainNav.tsx
+++ b/src/components/client/sidebar/SidebarMainNav.tsx
@@ -2,7 +2,7 @@
 
 import { useMemo } from 'react';
 import { useParams, usePathname, useRouter } from 'next/navigation';
-import { FileText, ShieldAlert } from 'lucide-react';
+import { FileText, ShieldAlert, LineChart } from 'lucide-react';
 import { useReports } from '@/hooks/workspace/useWorkspaceQuery';
 
 interface SidebarMainNavProps {
@@ -27,12 +27,15 @@ export function SidebarMainNav({ isOpen }: SidebarMainNavProps) {
   }, [workspaceId, params?.reportId, reports]);
 
   const crisisHref = workspaceId ? `/crisis/${workspaceId}` : '';
+  const monitoringHref = workspaceId ? `/monitoring/${workspaceId}` : '';
 
   const isReport = pathname.startsWith('/report/');
   const isCrisis = pathname.startsWith('/crisis/');
+  const isMonitoring = pathname.startsWith('/monitoring/');
 
   const items: { label: string; Icon: typeof FileText; href: string; active: boolean }[] = [
     { label: '보고서', Icon: FileText, href: reportHref, active: isReport },
+    { label: '모니터링', Icon: LineChart, href: monitoringHref, active: isMonitoring },
     { label: '위기 대응 센터', Icon: ShieldAlert, href: crisisHref, active: isCrisis },
   ];
 

--- a/src/hooks/monitoring/monitoringKeys.ts
+++ b/src/hooks/monitoring/monitoringKeys.ts
@@ -1,0 +1,9 @@
+export const monitoringKeys = {
+  all: ['monitoring'] as const,
+  daily: (workspaceId: string, start: string, end: string) =>
+    ['monitoring', workspaceId, 'daily', start, end] as const,
+  stock: (workspaceId: string, start: string, end: string) =>
+    ['monitoring', workspaceId, 'stock', start, end] as const,
+  risks: (workspaceId: string, start: string, end: string) =>
+    ['monitoring', workspaceId, 'risks', start, end] as const,
+};

--- a/src/hooks/monitoring/useMonitoringQuery.ts
+++ b/src/hooks/monitoring/useMonitoringQuery.ts
@@ -1,0 +1,39 @@
+import { useQuery } from '@tanstack/react-query';
+import {
+  getMonitoringDaily,
+  getMonitoringStock,
+  getMonitoringRisks,
+} from '@/lib/api/monitoringApi';
+import { monitoringKeys } from './monitoringKeys';
+
+const FIVE_MIN = 5 * 60 * 1000;
+
+/** workspace 의 [start, end] 범위 일별 수집량/감정 시계열. */
+export function useMonitoringDaily(workspaceId: string, start: string, end: string) {
+  return useQuery({
+    queryKey: monitoringKeys.daily(workspaceId, start, end),
+    queryFn: () => getMonitoringDaily(workspaceId, start, end),
+    enabled: !!workspaceId && !!start && !!end,
+    staleTime: FIVE_MIN,
+  });
+}
+
+/** workspace 의 [start, end] 범위 주가 OHLC 시계열. */
+export function useMonitoringStock(workspaceId: string, start: string, end: string) {
+  return useQuery({
+    queryKey: monitoringKeys.stock(workspaceId, start, end),
+    queryFn: () => getMonitoringStock(workspaceId, start, end),
+    enabled: !!workspaceId && !!start && !!end,
+    staleTime: FIVE_MIN,
+  });
+}
+
+/** workspace 의 [start, end] 범위 critical_type 별 일자 발생량. */
+export function useMonitoringRisks(workspaceId: string, start: string, end: string) {
+  return useQuery({
+    queryKey: monitoringKeys.risks(workspaceId, start, end),
+    queryFn: () => getMonitoringRisks(workspaceId, start, end),
+    enabled: !!workspaceId && !!start && !!end,
+    staleTime: FIVE_MIN,
+  });
+}

--- a/src/lib/api/monitoringApi.ts
+++ b/src/lib/api/monitoringApi.ts
@@ -1,0 +1,243 @@
+import { createClient } from '@/lib/supabase/client';
+import type { Database } from '@/types/database.types';
+
+const supabase = createClient();
+
+// ── 채널 매핑 ─────────────────────────────────────────────────────────
+// platforms 테이블의 5종을 4채널로 묶음 (커뮤니티 = naver_stock + dcinside)
+
+export type Channel = 'news' | 'blog' | 'youtube' | 'community';
+
+export const MONITORING_CHANNELS: { id: Channel; label: string }[] = [
+  { id: 'news', label: '뉴스' },
+  { id: 'blog', label: '블로그' },
+  { id: 'youtube', label: '유튜브' },
+  { id: 'community', label: '커뮤니티' },
+];
+
+const PLATFORM_TO_CHANNEL: Record<string, Channel> = {
+  naver_news: 'news',
+  naver_blog: 'blog',
+  youtube: 'youtube',
+  naver_stock: 'community',
+  dcinside: 'community',
+};
+
+export type CriticalType = Database['public']['Enums']['critical_type'];
+
+export const CRITICAL_TYPES: { id: CriticalType; label: string }[] = [
+  { id: 'defamation', label: '명예훼손' },
+  { id: 'insult', label: '모욕' },
+  { id: 'rumor', label: '허위사실' },
+  { id: 'spam', label: '스팸/광고' },
+];
+
+// ── 반환 타입 ─────────────────────────────────────────────────────────
+
+export interface MonitoringDayPoint {
+  date: string;                                    // YYYY-MM-DD
+  isCarried: boolean;
+  channelVolume: Record<Channel, number>;
+  totalVolume: number;
+  positive: number;
+  neutral: number;
+  negative: number;
+}
+
+export interface MonitoringStockPoint {
+  date: string;
+  open: number | null;
+  high: number | null;
+  low: number | null;
+  close: number;
+}
+
+export interface MonitoringRiskPoint {
+  date: string;
+  byType: Record<CriticalType, number>;
+  total: number;
+}
+
+// ── 페이지네이션 헬퍼 (reportApi.ts 와 동일 패턴) ────────────────────
+const _PAGE = 1000;
+async function fetchAllPaged<T>(
+  build: (from: number, to: number) => PromiseLike<{ data: T[] | null }>,
+): Promise<T[]> {
+  const all: T[] = [];
+  let off = 0;
+  while (true) {
+    const { data } = await build(off, off + _PAGE - 1);
+    const chunk = data ?? [];
+    all.push(...chunk);
+    if (chunk.length < _PAGE) break;
+    off += _PAGE;
+  }
+  return all;
+}
+
+function emptyChannelVolume(): Record<Channel, number> {
+  return { news: 0, blog: 0, youtube: 0, community: 0 };
+}
+
+function emptyByType(): Record<CriticalType, number> {
+  return { defamation: 0, insult: 0, rumor: 0, spam: 0 };
+}
+
+// ── API ───────────────────────────────────────────────────────────────
+
+/** daily_snapshots + daily_platform_stats 머지. 채널별 수집량/감정 일자 시계열. */
+export async function getMonitoringDaily(
+  workspaceId: string,
+  startDate: string,
+  endDate: string,
+): Promise<MonitoringDayPoint[]> {
+  const snapshots = await fetchAllPaged((from, to) =>
+    supabase
+      .from('daily_snapshots')
+      .select('id, date, is_carried')
+      .eq('workspace_id', workspaceId)
+      .gte('date', startDate)
+      .lte('date', endDate)
+      .order('date')
+      .range(from, to),
+  );
+
+  if (snapshots.length === 0) return [];
+
+  const ids = snapshots.map((s) => s.id);
+  const stats = await fetchAllPaged((from, to) =>
+    supabase
+      .from('daily_platform_stats')
+      .select(
+        'daily_snapshot_id, platform_id, content_count, positive_count, negative_count, neutral_count',
+      )
+      .in('daily_snapshot_id', ids)
+      .range(from, to),
+  );
+
+  type Acc = {
+    channelVolume: Record<Channel, number>;
+    positive: number;
+    neutral: number;
+    negative: number;
+    totalVolume: number;
+  };
+  const accBySnap = new Map<string, Acc>();
+  for (const s of stats) {
+    const channel = PLATFORM_TO_CHANNEL[s.platform_id];
+    if (!channel) continue;
+    const cur =
+      accBySnap.get(s.daily_snapshot_id) ?? {
+        channelVolume: emptyChannelVolume(),
+        positive: 0,
+        neutral: 0,
+        negative: 0,
+        totalVolume: 0,
+      };
+    cur.channelVolume[channel] += s.content_count;
+    cur.positive += s.positive_count;
+    cur.neutral += s.neutral_count;
+    cur.negative += s.negative_count;
+    cur.totalVolume += s.content_count;
+    accBySnap.set(s.daily_snapshot_id, cur);
+  }
+
+  return snapshots.map((s) => {
+    const acc = accBySnap.get(s.id) ?? {
+      channelVolume: emptyChannelVolume(),
+      positive: 0,
+      neutral: 0,
+      negative: 0,
+      totalVolume: 0,
+    };
+    return {
+      date: s.date,
+      isCarried: s.is_carried,
+      channelVolume: acc.channelVolume,
+      totalVolume: acc.totalVolume,
+      positive: acc.positive,
+      neutral: acc.neutral,
+      negative: acc.negative,
+    };
+  });
+}
+
+/** stock_prices 시계열. close 는 NOT NULL, 나머지는 nullable. */
+export async function getMonitoringStock(
+  workspaceId: string,
+  startDate: string,
+  endDate: string,
+): Promise<MonitoringStockPoint[]> {
+  const rows = await fetchAllPaged((from, to) =>
+    supabase
+      .from('stock_prices')
+      .select('date, open_price, high_price, low_price, close_price')
+      .eq('workspace_id', workspaceId)
+      .gte('date', startDate)
+      .lte('date', endDate)
+      .order('date')
+      .range(from, to),
+  );
+
+  return rows.map((r) => ({
+    date: r.date,
+    open: r.open_price,
+    high: r.high_price,
+    low: r.low_price,
+    close: r.close_price,
+  }));
+}
+
+/** news_items + community_items + sns_items 의 critical_type 발생을 일자/타입별로 집계.
+ *  published_at 기준. 필터에 `+09:00` offset 을 명시해 KST 자정 경계 어긋남 방지. */
+export async function getMonitoringRisks(
+  workspaceId: string,
+  startDate: string,
+  endDate: string,
+): Promise<MonitoringRiskPoint[]> {
+  const startISO = `${startDate}T00:00:00+09:00`;
+  // endDate 자정까지 포함 → 다음날 00:00 미만
+  const endNext = new Date(`${endDate}T00:00:00+09:00`);
+  endNext.setDate(endNext.getDate() + 1);
+  const endISO = endNext.toISOString();
+
+  type Row = { published_at: string | null; critical_type: CriticalType | null };
+
+  const buildItemQuery = (table: 'news_items' | 'community_items' | 'sns_items') => (
+    from: number,
+    to: number,
+  ) =>
+    supabase
+      .from(table)
+      .select('published_at, critical_type')
+      .eq('workspace_id', workspaceId)
+      .not('critical_type', 'is', null)
+      .gte('published_at', startISO)
+      .lt('published_at', endISO)
+      .range(from, to);
+
+  const [news, community, sns] = await Promise.all([
+    fetchAllPaged<Row>(buildItemQuery('news_items')),
+    fetchAllPaged<Row>(buildItemQuery('community_items')),
+    fetchAllPaged<Row>(buildItemQuery('sns_items')),
+  ]);
+
+  const byDate = new Map<string, Record<CriticalType, number>>();
+  for (const r of [...news, ...community, ...sns]) {
+    if (!r.published_at || !r.critical_type) continue;
+    // published_at 은 UTC ISO. KST 일자로 변환해서 묶음.
+    const kst = new Date(new Date(r.published_at).getTime() + 9 * 60 * 60 * 1000);
+    const date = kst.toISOString().slice(0, 10);
+    const cur = byDate.get(date) ?? emptyByType();
+    cur[r.critical_type] += 1;
+    byDate.set(date, cur);
+  }
+
+  return Array.from(byDate.entries())
+    .sort(([a], [b]) => a.localeCompare(b))
+    .map(([date, byType]) => ({
+      date,
+      byType,
+      total: byType.defamation + byType.insult + byType.rumor + byType.spam,
+    }));
+}


### PR DESCRIPTION
- (client) 그룹에 /monitoring/[workspaceId] 라우트 추가. 일자별 누적 데이터로 주가+수집량 / 감정 분포 / 리스크 발생 / 채널별 수집량 4종 차트 노출
- 시작·종료일 직접 선택 + 7/30/90/180/365 프리셋 칩, KPI 4종에 직전 동기간 비교 델타
- 3계층 분리 (lib/api/monitoringApi · hooks/monitoring/{Keys,Query})
- daily_snapshots + daily_platform_stats 머지 / stock_prices / 3 items 테이블의 critical_type 발생을 KST 일자 기준 집계
- ClientSidebar 에 LineChart 아이콘 모니터링 메뉴 추가 (보고서 ↔ 위기 사이)

