### PR TITLE
fix(front): React Compiler 룰 강화로 막힌 build 두 곳 우회

### DIFF
--- a/src/app/(client)/insights-history/[workspaceId]/page.tsx
+++ b/src/app/(client)/insights-history/[workspaceId]/page.tsx
@@ -56,6 +56,7 @@ export default function InsightsHistoryPage() {
   const filtered = useMemo(() => {
     if (range === 'all') return rows;
     const days = range === '7d' ? 7 : 30;
+    // eslint-disable-next-line react-hooks/purity -- range 변경 시 cutoff 재계산. 매 렌더 정밀 동기화 불필요.
     const cutoff = Date.now() - days * 86400000;
     return rows.filter((r) => new Date(r.created_at).getTime() >= cutoff);
   }, [rows, range]);

--- a/src/components/client/monitoring/AiAnalysisCard.tsx
+++ b/src/components/client/monitoring/AiAnalysisCard.tsx
@@ -45,6 +45,7 @@ export function AiAnalysisCard({ workspaceId }: Props) {
   // 최근 분석 결과가 처음 도착하면 카드 자동 펼침 (1회만 — 사용자가 닫으면 재펼침 X).
   useEffect(() => {
     if (!autoOpenedOnce && latestQ.data) {
+      // eslint-disable-next-line react-hooks/set-state-in-effect -- 외부 데이터(latestQ) 도착 시 1회 자동 펼침. ref 로 우회하면 의도 불명확.
       setOpen(true);
       setAutoOpenedOnce(true);
     }


### PR DESCRIPTION
- insights-history page: useMemo 내 Date.now() 에 react-hooks/purity disable (range 변경 시 cutoff 재계산, 매 렌더 정밀 동기화 불필요)
- AiAnalysisCard: 데이터 도착 시 1회 자동 펼침 useEffect 에 react-hooks/set-state-in-effect disable (의도된 외부 데이터 sync)
