### PR TITLE
feat(subscription): 예약(미시작) 구독 관리 + 목록 예약 상태 + 표 헤더 sticky

### DIFF
--- a/src/components/user/CustomerTable.tsx
+++ b/src/components/user/CustomerTable.tsx
@@ -31,17 +31,17 @@ export function CustomerTable({ users, tokens, onSelect }: CustomerTableProps) {
 
   return (
     <div className="flex-1 flex flex-col bg-white rounded-xl border border-slate-100 overflow-hidden">
-      {/* 데스크톱 테이블 헤더 */}
-      <div className="hidden lg:grid grid-cols-[1.2fr_1.6fr_0.7fr_1.3fr_0.6fr_0.9fr_0.7fr] border-b border-slate-100 py-3 px-4 text-xs font-semibold text-slate-500">
-        <div>회사명</div>
-        <div>이메일</div>
-        <div className="text-center">티어</div>
-        <div className="text-center">계약 기간</div>
-        <div className="text-center">남은</div>
-        <div className="text-center">AI 토큰 (잔여 / 월충전)</div>
-        <div className="text-center">상태</div>
-      </div>
       <div className="flex-1 overflow-y-auto">
+        {/* 데스크톱 헤더 — 스크롤 컨테이너 안 sticky. 행과 같은 폭(스크롤바 제외)을 공유해 칸 어긋남 방지 */}
+        <div className="hidden lg:grid grid-cols-[1.2fr_1.6fr_0.7fr_1.3fr_0.6fr_0.9fr_0.7fr] sticky top-0 z-10 bg-white border-b border-slate-100 py-3 px-4 text-xs font-semibold text-slate-500">
+          <div>회사명</div>
+          <div>이메일</div>
+          <div className="text-center">티어</div>
+          <div className="text-center">계약 기간</div>
+          <div className="text-center">남은</div>
+          <div className="text-center">AI 토큰 (잔여 / 월충전)</div>
+          <div className="text-center">상태</div>
+        </div>
         {sorted.length === 0 && (
           <p className="text-sm text-slate-400 py-8 text-center">등록된 사용자가 없습니다.</p>
         )}
@@ -53,11 +53,13 @@ export function CustomerTable({ users, tokens, onSelect }: CustomerTableProps) {
             ? `${format(parseISO(sub.started_at), 'yy.MM.dd')} ~ ${format(parseISO(sub.ended_at), 'yy.MM.dd')}`
             : '-';
           const remainLabel =
-            summary.daysUntilExpiry === null
-              ? '-'
-              : summary.daysUntilExpiry < 0
-                ? `${summary.daysUntilExpiry}일`
-                : `D-${summary.daysUntilExpiry}`;
+            summary.status === 'scheduled' && summary.daysUntilStart !== null
+              ? `D-${summary.daysUntilStart} 시작`
+              : summary.daysUntilExpiry === null
+                ? '-'
+                : summary.daysUntilExpiry < 0
+                  ? `${summary.daysUntilExpiry}일`
+                  : `D-${summary.daysUntilExpiry}`;
           const tierLabel = sub ? TIER_LABELS[sub.tier] : '-';
           const tk = u.workspace ? tokensByWs.get(u.workspace.id) : undefined;
           // 잔여 토큰이 월 충전량의 20% 미만이면 경고색, 0 이하면 빨간색

--- a/src/components/user/StaffTable.tsx
+++ b/src/components/user/StaffTable.tsx
@@ -20,14 +20,14 @@ export function StaffTable({ users, onSelect }: StaffTableProps) {
 
   return (
     <div className="flex-1 flex flex-col bg-white rounded-xl border border-slate-100 overflow-hidden">
-      {/* 데스크톱 헤더 */}
-      <div className="hidden lg:grid grid-cols-[1.2fr_1.8fr_0.8fr_1fr] border-b border-slate-100 py-3 px-4 text-xs font-semibold text-slate-500">
-        <div>회사명</div>
-        <div>이메일</div>
-        <div className="text-center">권한</div>
-        <div className="text-center">가입일</div>
-      </div>
       <div className="flex-1 overflow-y-auto">
+        {/* 데스크톱 헤더 — 스크롤 컨테이너 안 sticky. 행과 같은 폭(스크롤바 제외)을 공유해 칸 어긋남 방지 */}
+        <div className="hidden lg:grid grid-cols-[1.2fr_1.8fr_0.8fr_1fr] sticky top-0 z-10 bg-white border-b border-slate-100 py-3 px-4 text-xs font-semibold text-slate-500">
+          <div>회사명</div>
+          <div>이메일</div>
+          <div className="text-center">권한</div>
+          <div className="text-center">가입일</div>
+        </div>
         {sorted.length === 0 && (
           <p className="text-sm text-slate-400 py-8 text-center">등록된 관리자가 없습니다.</p>
         )}

--- a/src/components/user/UserDetailModal.tsx
+++ b/src/components/user/UserDetailModal.tsx
@@ -7,10 +7,11 @@ import { X, Plus } from 'lucide-react';
 import { AdminButton } from '@/components/ui/AdminButton';
 import { Button } from '@/components/ui/Button';
 import { Modal } from '@/components/ui/Modal';
+import { ConfirmModal } from '@/components/ui/ConfirmModal';
 import { ContractPeriodPicker } from '@/components/ui/ContractPeriodPicker';
 import { TierPicker } from '@/components/user/TierPicker';
 import { useUpdateUser, useUpdateWorkspaceTokens } from '@/hooks/user/useUserMutation';
-import { useActiveSubscription } from '@/hooks/subscription/useSubscriptionQuery';
+import { useCurrentOrUpcomingSubscription } from '@/hooks/subscription/useSubscriptionQuery';
 import {
   useChangeSubscriptionTier,
   useExtendSubscription,
@@ -18,11 +19,12 @@ import {
   usePauseSubscription,
   useCancelSubscription,
   useCorrectSubscription,
+  useDeleteScheduledSubscription,
 } from '@/hooks/subscription/useSubscriptionMutation';
 import { ROLE_LABEL } from '@/constants/role';
 import { TIER_LABELS, type Tier } from '@/types/subscription';
 import type { UserProfile, WorkspaceMember, WorkspaceTokens } from '@/lib/api/userApi';
-import type { Subscription } from '@/lib/api/subscriptionApi';
+import type { Subscription, SubscriptionStatus } from '@/lib/api/subscriptionApi';
 import type { ProfileRole } from '@/types/auth';
 
 type SubMode =
@@ -93,13 +95,22 @@ export function UserDetailModal({
       ? members.find((m) => m.profile_id === user.id)?.workspace_id
       : undefined;
 
-  const { data: fetchedSub } = useActiveSubscription(userWorkspaceId);
-  const activeSub: Subscription | null =
+  const { data: fetchedSub } = useCurrentOrUpcomingSubscription(userWorkspaceId);
+  // 현재 또는 예약 구독. 로딩 중엔 부모가 넘긴 활성 구독으로 fallback.
+  const sub: Subscription | null =
     fetchedSub !== undefined
-      ? (fetchedSub ?? null)
+      ? (fetchedSub?.subscription ?? null)
       : (initialSubscription ?? null);
+  const subStatus: SubscriptionStatus | null =
+    fetchedSub !== undefined
+      ? (fetchedSub?.status ?? null)
+      : (initialSubscription ? 'active' : null);
+  // 활성일 때만 활성 전용 액션(연장/정지/해지/티어변경) 노출
+  const activeSub: Subscription | null = subStatus === 'active' ? sub : null;
 
   const correctSub = useCorrectSubscription(userWorkspaceId);
+  const deleteScheduled = useDeleteScheduledSubscription(userWorkspaceId);
+  const [confirmDeleteOpen, setConfirmDeleteOpen] = useState(false);
 
   useEffect(() => {
     if (user) {
@@ -121,14 +132,14 @@ export function UserDetailModal({
   };
 
   const enterMode = (mode: SubMode) => {
-    if (mode === 'change_tier' && activeSub) {
-      setFormTier(activeSub.tier);
-    } else if (mode === 'extend' && activeSub) {
-      setFormEnd(parseISO(activeSub.ended_at));
-    } else if (mode === 'correct' && activeSub) {
-      setFormTier(activeSub.tier);
-      setFormStart(parseISO(activeSub.started_at));
-      setFormEnd(parseISO(activeSub.ended_at));
+    if (mode === 'change_tier' && sub) {
+      setFormTier(sub.tier);
+    } else if (mode === 'extend' && sub) {
+      setFormEnd(parseISO(sub.ended_at));
+    } else if (mode === 'correct' && sub) {
+      setFormTier(sub.tier);
+      setFormStart(parseISO(sub.started_at));
+      setFormEnd(parseISO(sub.ended_at));
     } else if (mode === 'new') {
       const today = new Date();
       const oneYearLater = new Date(today);
@@ -174,7 +185,8 @@ export function UserDetailModal({
     renewSub.isPending ||
     pauseSub.isPending ||
     cancelSub.isPending ||
-    correctSub.isPending;
+    correctSub.isPending ||
+    deleteScheduled.isPending;
   const saving = updateUser.isPending || subBusy;
 
   // 사용자 역할은 sub 작업이 별도 흐름이므로, 메인 저장은 role 변경만 다룸
@@ -293,10 +305,10 @@ export function UserDetailModal({
   };
 
   const submitCorrect = async () => {
-    if (!activeSub || !formTier || !formStart || !formEnd) return;
+    if (!sub || !formTier || !formStart || !formEnd) return;
     try {
       await correctSub.mutateAsync({
-        subscriptionId: activeSub.id,
+        subscriptionId: sub.id,
         tier: formTier,
         startedAt: formStart.toISOString(),
         endedAt: formEnd.toISOString(),
@@ -308,10 +320,23 @@ export function UserDetailModal({
     }
   };
 
+  const submitDeleteScheduled = async () => {
+    if (!sub) return;
+    try {
+      await deleteScheduled.mutateAsync({ subscriptionId: sub.id });
+      toast.success('예약 구독이 취소되었습니다.');
+      setConfirmDeleteOpen(false);
+      resetSubForm();
+    } catch (e) {
+      toast.error(`예약 취소 실패: ${formatErr(e)}`);
+    }
+  };
+
   const assignedWs = filteredWs.filter((ws) => pendingWs.includes(ws.id));
   const unassignedWs = filteredWs.filter((ws) => !pendingWs.includes(ws.id));
 
   return (
+    <>
     <Modal
       open={open}
       onClose={onClose}
@@ -367,20 +392,25 @@ export function UserDetailModal({
               <span className="text-xs font-semibold text-slate-600 mb-1 block">
                 현재 계약
               </span>
-              {activeSub ? (
+              {sub ? (
                 <p className="text-sm text-slate-700">
-                  <span className="font-semibold">{TIER_LABELS[activeSub.tier]}</span>
+                  <span className="font-semibold">{TIER_LABELS[sub.tier]}</span>
                   {' · '}
-                  {format(parseISO(activeSub.started_at), 'yyyy-MM-dd')}
+                  {format(parseISO(sub.started_at), 'yyyy-MM-dd')}
                   {' ~ '}
-                  {format(parseISO(activeSub.ended_at), 'yyyy-MM-dd')}
+                  {format(parseISO(sub.ended_at), 'yyyy-MM-dd')}
+                  {subStatus === 'scheduled' && (
+                    <span className="ml-2 inline-block rounded-full bg-amber-100 text-amber-700 text-[11px] px-2 py-0.5 font-medium align-middle">
+                      {format(parseISO(sub.started_at), 'M월 d일')} 시작 예정
+                    </span>
+                  )}
                 </p>
               ) : (
-                <p className="text-sm text-slate-400">활성 구독이 없습니다.</p>
+                <p className="text-sm text-slate-400">구독이 없습니다.</p>
               )}
             </div>
 
-            {canEditSub && subMode === 'idle' && activeSub && (
+            {canEditSub && subMode === 'idle' && subStatus === 'active' && (
               <div className="flex flex-col gap-2">
                 <div className="grid grid-cols-2 gap-2">
                   <AdminButton size="sm" variant="primary" onClick={() => enterMode('change_tier')}>
@@ -406,7 +436,27 @@ export function UserDetailModal({
               </div>
             )}
 
-            {canEditSub && subMode === 'idle' && !activeSub && (
+            {canEditSub && subMode === 'idle' && subStatus === 'scheduled' && (
+              <div className="flex flex-col gap-2">
+                <p className="text-xs text-slate-500">
+                  아직 시작 전인 예약 구독입니다. 시작일·티어를 정정하거나 예약을 취소할 수 있습니다.
+                </p>
+                <div className="grid grid-cols-2 gap-2">
+                  <AdminButton size="sm" variant="primary" onClick={() => enterMode('correct')}>
+                    정보 정정
+                  </AdminButton>
+                  <AdminButton
+                    size="sm"
+                    variant="secondary"
+                    onClick={() => setConfirmDeleteOpen(true)}
+                  >
+                    예약 취소
+                  </AdminButton>
+                </div>
+              </div>
+            )}
+
+            {canEditSub && subMode === 'idle' && !sub && (
               <AdminButton size="sm" variant="primary" onClick={() => enterMode('new')}>
                 새 구독 시작
               </AdminButton>
@@ -719,6 +769,21 @@ export function UserDetailModal({
         )}
       </div>
     </Modal>
+    <ConfirmModal
+      open={confirmDeleteOpen}
+      onClose={() => setConfirmDeleteOpen(false)}
+      onConfirm={submitDeleteScheduled}
+      title="예약 구독 취소"
+      message={
+        sub
+          ? `${TIER_LABELS[sub.tier]} · ${format(parseISO(sub.started_at), 'yyyy-MM-dd')} 시작 예약을 취소(삭제)합니다. 되돌릴 수 없습니다.`
+          : ''
+      }
+      confirmLabel="예약 취소"
+      confirmVariant="danger"
+      loading={deleteScheduled.isPending}
+    />
+    </>
   );
 }
 

--- a/src/hooks/subscription/useSubscriptionMutation.ts
+++ b/src/hooks/subscription/useSubscriptionMutation.ts
@@ -6,6 +6,7 @@ import {
   pauseSubscription,
   cancelSubscription,
   correctSubscription,
+  deleteScheduledSubscription,
 } from '@/lib/api/subscriptionApi';
 import { subscriptionKeys } from '@/hooks/subscription/useSubscriptionQuery';
 import { userKeys } from '@/hooks/user/useUserQuery';
@@ -13,7 +14,8 @@ import { userKeys } from '@/hooks/user/useUserQuery';
 function useInvalidateOnSuccess() {
   const queryClient = useQueryClient();
   return (workspaceId: string) => {
-    queryClient.invalidateQueries({ queryKey: subscriptionKeys.active(workspaceId) });
+    // workspace prefix → active/current 구독 쿼리 모두 무효화
+    queryClient.invalidateQueries({ queryKey: subscriptionKeys.workspace(workspaceId) });
     queryClient.invalidateQueries({ queryKey: userKeys.usersDetailed() });
   };
 }
@@ -62,6 +64,16 @@ export function useCorrectSubscription(workspaceId: string | undefined) {
   const invalidate = useInvalidateOnSuccess();
   return useMutation({
     mutationFn: correctSubscription,
+    onSuccess: () => {
+      if (workspaceId) invalidate(workspaceId);
+    },
+  });
+}
+
+export function useDeleteScheduledSubscription(workspaceId: string | undefined) {
+  const invalidate = useInvalidateOnSuccess();
+  return useMutation({
+    mutationFn: deleteScheduledSubscription,
     onSuccess: () => {
       if (workspaceId) invalidate(workspaceId);
     },

--- a/src/hooks/subscription/useSubscriptionQuery.ts
+++ b/src/hooks/subscription/useSubscriptionQuery.ts
@@ -1,18 +1,24 @@
 import { useQuery } from '@tanstack/react-query';
-import { getActiveSubscription } from '@/lib/api/subscriptionApi';
+import { getCurrentOrUpcomingSubscription } from '@/lib/api/subscriptionApi';
 
 export const subscriptionKeys = {
   all: ['subscriptions'] as const,
-  active: (workspaceId: string) =>
-    ['subscriptions', workspaceId, 'active'] as const,
+  /** 워크스페이스 단위 prefix — invalidate 시 하위 구독 쿼리 모두 무효화 */
+  workspace: (workspaceId: string) => ['subscriptions', workspaceId] as const,
+  current: (workspaceId: string) =>
+    ['subscriptions', workspaceId, 'current'] as const,
 };
 
-export function useActiveSubscription(workspaceId: string | undefined) {
+/** 현재 활성 또는 미래 예약 구독 1건 (관리자 모달용) */
+export function useCurrentOrUpcomingSubscription(
+  workspaceId: string | undefined,
+) {
   return useQuery({
     queryKey: workspaceId
-      ? subscriptionKeys.active(workspaceId)
+      ? subscriptionKeys.current(workspaceId)
       : ['subscriptions', 'none'],
-    queryFn: () => (workspaceId ? getActiveSubscription(workspaceId) : null),
+    queryFn: () =>
+      workspaceId ? getCurrentOrUpcomingSubscription(workspaceId) : null,
     enabled: !!workspaceId,
   });
 }

--- a/src/lib/api/subscriptionApi.ts
+++ b/src/lib/api/subscriptionApi.ts
@@ -32,6 +32,42 @@ export async function getActiveSubscription(
   return (data as Subscription | null) ?? null;
 }
 
+export type SubscriptionStatus = 'active' | 'scheduled';
+
+export interface CurrentOrUpcomingSubscription {
+  subscription: Subscription;
+  /** active = 지금 진행 중 / scheduled = 미래 시작 예약 */
+  status: SubscriptionStatus;
+}
+
+/**
+ * 현재 또는 다가오는 구독 1건 조회.
+ * 아직 안 끝난(ended_at > NOW) segment 중 started_at 이 가장 이른 것을 고른다.
+ * - 활성(started_at <= NOW) segment 가 있으면 그게 먼저 잡혀 status='active'
+ * - 없고 미래 시작 segment 만 있으면 status='scheduled'
+ * 관리자 모달에서 예약 구독도 인식·관리하기 위한 조회.
+ */
+export async function getCurrentOrUpcomingSubscription(
+  workspaceId: string,
+): Promise<CurrentOrUpcomingSubscription | null> {
+  const nowIso = new Date().toISOString();
+  const { data } = await supabase
+    .from('subscriptions')
+    .select('*')
+    .eq('workspace_id', workspaceId)
+    .gt('ended_at', nowIso)
+    .order('started_at', { ascending: true })
+    .limit(1)
+    .maybeSingle();
+
+  const sub = (data as Subscription | null) ?? null;
+  if (!sub) return null;
+  return {
+    subscription: sub,
+    status: new Date(sub.started_at).getTime() <= Date.now() ? 'active' : 'scheduled',
+  };
+}
+
 /** 중간 구독제 변경: 활성 row 자르고 새 tier 로 새 row INSERT (DB transaction). */
 export async function changeSubscriptionTier(input: {
   workspaceId: string;
@@ -98,6 +134,17 @@ export async function cancelSubscription(input: {
   const { data, error } = await supabase.rpc('cancel_subscription', {
     p_workspace_id: input.workspaceId,
     p_cancel_at: input.cancelAt ?? new Date().toISOString(),
+  });
+  if (error) throw error;
+  return data as string;
+}
+
+/** 예약(미시작) 구독 취소 — started_at > NOW 인 row 만 삭제 (RPC 가드). */
+export async function deleteScheduledSubscription(input: {
+  subscriptionId: string;
+}): Promise<string> {
+  const { data, error } = await supabase.rpc('delete_scheduled_subscription', {
+    p_subscription_id: input.subscriptionId,
   });
   if (error) throw error;
   return data as string;

--- a/src/lib/api/userApi.ts
+++ b/src/lib/api/userApi.ts
@@ -34,7 +34,7 @@ export interface UserWorkspace {
 export interface UserWithDetails extends UserProfile {
   /** role='user' 인 경우 배정된 단일 워크스페이스 */
   workspace?: UserWorkspace;
-  /** role='user' 인 경우 해당 워크스페이스의 활성 구독 */
+  /** role='user' 인 경우 해당 워크스페이스의 활성 또는 예약(미래 시작) 구독 */
   subscription?: Subscription;
   /** 배정된 워크스페이스 id 목록 (admin/super_admin 은 복수 가능) */
   workspaceIds: string[];
@@ -56,12 +56,13 @@ export async function getUsersWithDetails(): Promise<UserWithDetails[]> {
       .order('created_at', { ascending: false }),
     supabase.from('workspace_members').select('workspace_id, profile_id'),
     supabase.from('workspaces').select('id, company_name, ticker'),
+    // 활성(started<=now<ended) + 예약(started>now) 모두. ended<=now(만료)만 제외.
+    // started_at 오름차순 → 워크스페이스별 첫 row = 활성(있으면) 또는 가장 이른 예약.
     supabase
       .from('subscriptions')
       .select('*')
-      .lte('started_at', nowIso)
       .gt('ended_at', nowIso)
-      .order('started_at', { ascending: false }),
+      .order('started_at', { ascending: true }),
   ]);
 
   const users = (usersR.data ?? []) as UserProfile[];

--- a/src/lib/subscription.ts
+++ b/src/lib/subscription.ts
@@ -1,29 +1,42 @@
 import { differenceInCalendarDays, parseISO } from 'date-fns';
 import type { Subscription } from '@/lib/api/subscriptionApi';
 
-export type ContractStatus = 'active' | 'expiring' | 'expired' | 'none';
+export type ContractStatus =
+  | 'scheduled'
+  | 'active'
+  | 'expiring'
+  | 'expired'
+  | 'none';
 
 export interface ContractSummary {
   status: ContractStatus;
   /** 오늘 기준 종료일까지 남은 일수. 무기한이거나 구독 없으면 null */
   daysUntilExpiry: number | null;
+  /** scheduled 일 때 시작까지 남은 일수. 그 외 null */
+  daysUntilStart: number | null;
 }
 
-/** 활성 구독 하나를 받아 계약 상태와 남은 일수를 판정 */
+/** 구독 하나(활성 또는 예약)를 받아 계약 상태와 남은 일수를 판정 */
 export function getContractSummary(
   sub: Subscription | null | undefined,
 ): ContractSummary {
-  if (!sub) return { status: 'none', daysUntilExpiry: null };
+  if (!sub) return { status: 'none', daysUntilExpiry: null, daysUntilStart: null };
 
-  const end = parseISO(sub.ended_at);
-  const days = differenceInCalendarDays(end, new Date());
+  const now = new Date();
+  const daysToStart = differenceInCalendarDays(parseISO(sub.started_at), now);
+  const days = differenceInCalendarDays(parseISO(sub.ended_at), now);
 
-  if (days < 0) return { status: 'expired', daysUntilExpiry: days };
-  if (days <= 7) return { status: 'expiring', daysUntilExpiry: days };
-  return { status: 'active', daysUntilExpiry: days };
+  // 아직 시작 전 = 예약
+  if (daysToStart > 0) {
+    return { status: 'scheduled', daysUntilExpiry: days, daysUntilStart: daysToStart };
+  }
+  if (days < 0) return { status: 'expired', daysUntilExpiry: days, daysUntilStart: null };
+  if (days <= 7) return { status: 'expiring', daysUntilExpiry: days, daysUntilStart: null };
+  return { status: 'active', daysUntilExpiry: days, daysUntilStart: null };
 }
 
 export const CONTRACT_STATUS_STYLE: Record<ContractStatus, { label: string; className: string }> = {
+  scheduled: { label: '시작 예정', className: 'bg-amber-50 text-amber-700' },
   active: { label: '활성', className: 'bg-emerald-50 text-emerald-700' },
   expiring: { label: '만료 임박', className: 'bg-red-50 text-red-700' },
   expired: { label: '만료', className: 'bg-slate-100 text-slate-400' },

--- a/src/types/database.types.ts
+++ b/src/types/database.types.ts
@@ -1418,6 +1418,10 @@ export type Database = {
         Args: { p_links: string[]; p_session_id: string }
         Returns: number
       }
+      delete_scheduled_subscription: {
+        Args: { p_subscription_id: string }
+        Returns: string
+      }
       extend_subscription: {
         Args: { p_new_ended_at: string; p_workspace_id: string }
         Returns: string


### PR DESCRIPTION
- 관리자 모달: 활성 OR 미래 예약 구독 조회(useCurrentOrUpcomingSubscription) → '시작 예정' 배지 + 정정 + 예약 취소(delete_scheduled_subscription)
- 유저 목록: 활성 전용 조회를 활성+예약으로 확장, '시작 예정' 상태/뱃지(D-n 시작)
- CustomerTable/StaffTable: 헤더를 스크롤 컨테이너 안 sticky 로 옮겨 스크롤바 폭만큼 칸 밀리던 문제 해소
