### PR TITLE
fix(client): 위기 대응 센터 리스트 표시 영역 확대 + 달력 모달 초기 상태 보정

### DIFF
--- a/src/app/(client)/crisis/[workspaceId]/page.tsx
+++ b/src/app/(client)/crisis/[workspaceId]/page.tsx
@@ -129,8 +129,8 @@ export default function CrisisCenterPage() {
   const loading = itemsLoading || reportsLoading;
 
   return (
-    <div className="h-full bg-white flex flex-col">
-      <div className="mx-auto w-full lg:w-[1200px] px-4 lg:px-10 py-6 lg:py-10 flex flex-col gap-6 flex-1 min-h-0">
+    <div className="bg-white">
+      <div className="mx-auto w-full lg:w-[1200px] px-4 lg:px-10 py-6 lg:py-10 flex flex-col gap-6">
         <CrisisHeader companyName={workspace?.company_name} />
 
         {/* 탭 + 기간 필터 — 콘텐츠 컨트롤 한 줄 */}
@@ -176,11 +176,7 @@ export default function CrisisCenterPage() {
         {!armorReady || loading ? (
           <Loading />
         ) : activeTab === 'detection' ? (
-          <ReportCard
-            px={20}
-            py={10}
-            className="flex-1 min-h-0 flex flex-col"
-          >
+          <ReportCard px={20} py={10}>
             <RiskTable
               riskItems={riskItems ?? []}
               workspaceId={workspaceId}
@@ -192,7 +188,6 @@ export default function CrisisCenterPage() {
               allowReport={hasArmor}
               sessionToReportMap={sessionToReportMap ?? undefined}
               reportTypeMap={reportTypeMap}
-              fillHeight
             />
           </ReportCard>
         ) : (

--- a/src/components/client/sidebar/ReportCalendarModal.tsx
+++ b/src/components/client/sidebar/ReportCalendarModal.tsx
@@ -59,11 +59,13 @@ export function ReportCalendarModal({
   onSelect,
   onClose,
 }: ReportCalendarModalProps) {
-  // 현재 보고 있는 보고서 type 에 따라 초기 모드 결정
+  // 현재 보고 있는 보고서 type 에 따라 초기 모드 결정.
+  // 전체 보기(currentReportId 없음) 진입 시 — 가장 넓은 기간을 다루는 초기 종합으로.
   const [mode, setMode] = useState<Mode>(() => {
     const current = reports.find((r) => r.id === currentReportId);
     if (current?.type === 'daily') return 'daily';
     if (current?.type === 'initial') return 'monthly';
+    if (!currentReportId) return 'monthly';
     return 'weekly';
   });
 
@@ -74,9 +76,18 @@ export function ReportCalendarModal({
   );
 
   const [selectedReportId, setSelectedReportId] = useState<string | undefined>(currentReportId);
+  // 달력 시점 — 현재 보고서 있으면 그 period_end, 없으면 최신 보고서의 period_end 로 폴백.
+  // 폴백 없으면 month 가 undefined 라 nnnn년 n월 라벨이 비어 보이는 버그 발생.
   const [month, setMonth] = useState<Date | undefined>(() => {
     const current = reports.find((r) => r.id === currentReportId);
-    return current?.period_end ? (parseDate(current.period_end) ?? undefined) : undefined;
+    if (current?.period_end) return parseDate(current.period_end) ?? undefined;
+    const latestEnd = reports
+      .map((r) => r.period_end)
+      .filter((d): d is string => !!d)
+      .sort()
+      .pop();
+    if (latestEnd) return parseDate(latestEnd) ?? undefined;
+    return new Date();
   });
 
   // 날짜 → 보고서 매핑 (현재 모드 내에서만)

--- a/src/components/crisis/CrisisProcessedReports.tsx
+++ b/src/components/crisis/CrisisProcessedReports.tsx
@@ -35,34 +35,30 @@ export function CrisisProcessedReports({
   onUpgradeClick,
 }: CrisisProcessedReportsProps) {
   return (
-    <div className="flex flex-col flex-1 min-h-0">
-      <ReportCard
-        px={20}
-        py={!hasArmor ? 32 : 10}
-        className="flex-1 min-h-0 flex flex-col"
-      >
+    <div>
+      <ReportCard px={20} py={!hasArmor ? 32 : 10}>
         {!hasArmor ? (
-          <div className="flex-1 min-h-0 flex items-center justify-center">
+          <div className="flex items-center justify-center py-10">
             <UpgradePrompt onClick={onUpgradeClick} />
           </div>
         ) : reports.length === 0 ? (
-          <div className="flex-1 min-h-0 flex flex-col">
-            <div className="flex-1 min-h-0 flex items-center justify-center">
+          <>
+            <div className="flex items-center justify-center py-10">
               <EmptyState message="처리된 내역이 없습니다." />
             </div>
-            <p className="text-xs text-text-muted text-center py-2 shrink-0">총 0건</p>
-          </div>
+            <p className="text-xs text-text-muted text-center py-2">총 0건</p>
+          </>
         ) : (
-          <div className="flex-1 min-h-0 flex flex-col">
+          <>
             <DesktopTable reports={reports} />
             <MobileList reports={reports} />
-            <p className="text-xs text-text-muted text-center py-2 shrink-0">
+            <p className="text-xs text-text-muted text-center py-2">
               총 {reports.length}건
             </p>
-          </div>
+          </>
         )}
       </ReportCard>
-      <p className="text-xs text-text-muted mt-3 leading-relaxed shrink-0">
+      <p className="text-xs text-text-muted mt-3 leading-relaxed">
         공휴일에는 신고 처리가 불가합니다. 공휴일에 신고를 요청하시는 경우, 공휴일 다음 영업일부터 순차적으로 신고 처리를 진행합니다.
       </p>
     </div>
@@ -86,9 +82,9 @@ function UpgradePrompt({ onClick }: { onClick: () => void }) {
 
 function DesktopTable({ reports }: { reports: RiskReport[] }) {
   return (
-    <div className="hidden lg:flex flex-col flex-1 min-h-0">
+    <div className="hidden lg:block">
       <div
-        className="grid border-b border-border-light py-3 px-3 text-xs font-semibold text-text-muted text-center shrink-0"
+        className="grid border-b border-border-light py-3 px-3 text-xs font-semibold text-text-muted text-center"
         style={{ gridTemplateColumns: COL_TEMPLATE }}
       >
         <div>신고일</div>
@@ -97,7 +93,7 @@ function DesktopTable({ reports }: { reports: RiskReport[] }) {
         <div>신고 게시물</div>
         <div>처리 결과</div>
       </div>
-      <div className="flex-1 min-h-0 overflow-y-auto">
+      <div className="max-h-[600px] overflow-y-auto">
         {reports.map((rr) => {
           const statusCfg = STATUS_STYLES[rr.status] ?? { label: rr.status, className: 'bg-slate-100 text-slate-600' };
           return (
@@ -144,7 +140,7 @@ function DesktopTable({ reports }: { reports: RiskReport[] }) {
 
 function MobileList({ reports }: { reports: RiskReport[] }) {
   return (
-    <div className="lg:hidden flex flex-col gap-3 py-3 flex-1 min-h-0 overflow-y-auto">
+    <div className="lg:hidden flex flex-col gap-3 py-3 max-h-[400px] overflow-y-auto">
       {reports.map((rr) => {
         const statusCfg = STATUS_STYLES[rr.status] ?? { label: rr.status, className: 'bg-slate-100 text-slate-600' };
         return (


### PR DESCRIPTION
- crisis page / CrisisProcessedReports: fillHeight flex-1 min-h-0 체인 제거. RiskTable·테이블·모바일 카드 모두 max-h 내부 스크롤(600/400px)로 폴백해서 뷰포트가 작아도 데스크톱 5~6건 / 모바일 2~3건은 안정적으로 노출.
- ReportCalendarModal: 전체 보기(currentReportId 없음) 진입 시 mode 기본값을 'monthly'(초기 종합)로, month state 는 최신 보고서 period_end 로 폴백. 좌우 nav 누르기 전까지 nnnn년 n월 라벨이 비어 보이던 버그 수정.

