### PR TITLE
perf(admin): 관리자 페이지 전환 속도 개선 (홈 1.4s → 0.15~0.5s)

### DIFF
--- a/src/app/(app)/crawl-history/page.tsx
+++ b/src/app/(app)/crawl-history/page.tsx
@@ -4,10 +4,12 @@ import { CrawlHistoryClient } from './CrawlHistoryClient';
 
 // 크롤 히스토리 — 보존 모드 데이터 디버깅용. super_admin 전용.
 export default async function CrawlHistoryPage() {
+  const _t0 = Date.now();
   const user = await getCurrentUser();
   if (!user) redirect('/auth/login');
   if (user.role !== 'super_admin') {
     redirect('/workspace');
   }
+  console.log(`[NAV] page /crawl-history: ${Date.now() - _t0}ms`);
   return <CrawlHistoryClient />;
 }

--- a/src/app/(app)/layout.tsx
+++ b/src/app/(app)/layout.tsx
@@ -5,6 +5,7 @@ import { createClient } from '@/lib/supabase/server';
 import { AppShell } from '@/components/ui/AppShell';
 
 export default async function AppLayout({ children }: { children: React.ReactNode }) {
+  const _t0 = Date.now();
   const user = await getCurrentUser();
 
   // user 역할은 관리자 AppShell 에 절대 진입 불가. middleware/로그인 액션이 먼저 잡지만,
@@ -12,8 +13,10 @@ export default async function AppLayout({ children }: { children: React.ReactNod
   if (user?.role === 'user') {
     const supabase = await createClient();
     const target = (await resolveUserReportPath(supabase, user.id)) ?? '/no-report';
+    console.log(`[NAV] (app)/layout: ${Date.now() - _t0}ms (redirect=user-report)`);
     redirect(target);
   }
 
+  console.log(`[NAV] (app)/layout: ${Date.now() - _t0}ms`);
   return <AppShell user={user}>{children}</AppShell>;
 }

--- a/src/app/(app)/loading.tsx
+++ b/src/app/(app)/loading.tsx
@@ -1,0 +1,13 @@
+import { AdminLoading } from '@/components/ui/AdminLoading';
+
+// (app) 라우트 그룹 전체에 적용되는 loading UI.
+// AppShell(layout) 은 그대로 유지되고 본문만 이 컴포넌트로 교체됨 → RSC 가 도착하면 실제 페이지로 swap.
+export default function AppLoading() {
+  // AppShell <main> 은 `flex-1 overflow-y-auto` 라 flex 컨테이너가 아님 → AdminLoading 의
+  // `flex-1 + justify-center` 가 먹히도록 h-full flex wrapper 로 감싸야 상하 중앙정렬됨.
+  return (
+    <div className="h-full w-full flex">
+      <AdminLoading />
+    </div>
+  );
+}

--- a/src/app/(app)/ops/page.tsx
+++ b/src/app/(app)/ops/page.tsx
@@ -4,10 +4,12 @@ import { OpsClient } from './OpsClient';
 
 // 모니터링은 super_admin / admin 전용. 나머지 역할은 /workspace 로 리다이렉트.
 export default async function OpsPage() {
+  const _t0 = Date.now();
   const user = await getCurrentUser();
   if (!user) redirect('/auth/login');
   if (user.role !== 'super_admin' && user.role !== 'admin') {
     redirect('/workspace');
   }
+  console.log(`[NAV] page /ops: ${Date.now() - _t0}ms`);
   return <OpsClient />;
 }

--- a/src/app/(app)/page.tsx
+++ b/src/app/(app)/page.tsx
@@ -13,13 +13,17 @@ export default async function HomePage({
 }: {
   searchParams: Promise<{ window?: string }>;
 }) {
+  const _t0 = Date.now();
   const user = await getCurrentUser();
   if (!user) redirect('/auth/login');
   // user 역할 분기는 (app)/layout.tsx 에서 처리되므로 여기선 admin/super_admin 만 도달.
 
   const sp = await searchParams;
   const windowHours = parseAdminHomeWindow(sp.window);
+  const _tHome0 = Date.now();
   const data = await loadAdminHome(user.role, user.id, windowHours);
+  const _homeMs = Date.now() - _tHome0;
+  console.log(`[NAV] page / : ${Date.now() - _t0}ms (loadAdminHome=${_homeMs}ms)`);
   const greetingName = user.companyName || user.email.split('@')[0];
   const roleLabel = user.role === 'super_admin' ? '최고 관리자' : '관리자';
 

--- a/src/app/(app)/risk-reports/page.tsx
+++ b/src/app/(app)/risk-reports/page.tsx
@@ -6,6 +6,7 @@ import { RiskReportsClient } from './RiskReportsClient';
 // RLS 개방(031) 이후 클라이언트에서 risk_reports/workspaces 전체가 조회되므로
 // admin 역할은 workspace_members 에 등록된 워크스페이스만 보이도록 서버에서 스코프 계산.
 export default async function RiskReportsPage() {
+  const _t0 = Date.now();
   const user = await getCurrentUser();
   if (!user) redirect('/auth/login');
   if (user.role !== 'super_admin' && user.role !== 'admin') {
@@ -13,14 +14,18 @@ export default async function RiskReportsPage() {
   }
 
   let assignedIds: string[] | null = null;
+  let _membersMs = 0;
   if (user.role === 'admin') {
     const supabase = await createClient();
+    const _tM = Date.now();
     const { data } = await supabase
       .from('workspace_members')
       .select('workspace_id')
       .eq('profile_id', user.id);
+    _membersMs = Date.now() - _tM;
     assignedIds = (data ?? []).map((row) => row.workspace_id);
   }
+  console.log(`[NAV] page /risk-reports: ${Date.now() - _t0}ms (members=${_membersMs}ms)`);
 
   return <RiskReportsClient assignedIds={assignedIds} />;
 }

--- a/src/app/(app)/workspace/page.tsx
+++ b/src/app/(app)/workspace/page.tsx
@@ -6,18 +6,23 @@ import { WorkspaceListClient } from './WorkspaceListClient';
 // RLS 개방(031) 이후 클라이언트 `workspaces` SELECT 가 전체를 반환하므로
 // admin 역할은 workspace_members 에 등록된 워크스페이스만 보이도록 서버에서 스코프 계산.
 export default async function WorkspacePage() {
+  const _t0 = Date.now();
   const user = await getCurrentUser();
   if (!user) redirect('/auth/login');
 
   let assignedIds: string[] | null = null;
+  let _membersMs = 0;
   if (user.role === 'admin') {
     const supabase = await createClient();
+    const _tM = Date.now();
     const { data } = await supabase
       .from('workspace_members')
       .select('workspace_id')
       .eq('profile_id', user.id);
+    _membersMs = Date.now() - _tM;
     assignedIds = (data ?? []).map((row) => row.workspace_id);
   }
+  console.log(`[NAV] page /workspace: ${Date.now() - _t0}ms (members=${_membersMs}ms)`);
 
   return <WorkspaceListClient assignedIds={assignedIds} />;
 }

--- a/src/lib/adminHome/queries.ts
+++ b/src/lib/adminHome/queries.ts
@@ -59,8 +59,11 @@ export async function loadAdminHome(
   userId: string,
   windowHours: AdminHomeWindowHours = 24,
 ): Promise<AdminHomeData> {
+  const _t0 = Date.now();
   const supabase = await createClient();
+  const _tScope = Date.now();
   const assignedIds = await resolveScope(role, userId);
+  const _scopeMs = Date.now() - _tScope;
   const scope: 'all' | 'assigned' = assignedIds === null ? 'all' : 'assigned';
   const generatedAt = new Date().toISOString();
   const since = new Date(Date.now() - windowHours * 60 * 60 * 1000).toISOString();
@@ -79,7 +82,8 @@ export async function loadAdminHome(
     };
   }
 
-  // A. 최근 24h 실패 pipeline_runs
+  // 6개 쿼리 빌더를 모두 만들어 두고 Promise.all 로 한 번에 발사.
+  // (기존: scope → A → B1 → B2(병렬 3개) → C 가 직렬이라 가장 느린 쿼리의 합으로 1초+)
   const pipelineQuery = supabase
     .from('pipeline_runs')
     .select('id, workspace_id, report_type, started_at, error_stage, error_message, workspaces!inner(company_name)')
@@ -88,7 +92,63 @@ export async function loadAdminHome(
     .order('started_at', { ascending: false })
     .limit(10);
   if (assignedIds) pipelineQuery.in('workspace_id', assignedIds);
-  const { data: pipelineRows } = await pipelineQuery;
+
+  const riskQuery = supabase
+    .from('risk_reports')
+    .select('id, workspace_id, title, critical_type, requested_at, workspaces!inner(company_name)', {
+      count: 'exact',
+    })
+    .not('status', 'in', '("resolved","rejected")')
+    .order('requested_at', { ascending: false })
+    .limit(5);
+  if (assignedIds) riskQuery.in('workspace_id', assignedIds);
+
+  const newsCritQuery = supabase
+    .from('news_items')
+    .select('id', { count: 'exact', head: true })
+    .not('critical_type', 'is', null)
+    .gte('created_at', since);
+  if (assignedIds) newsCritQuery.in('workspace_id', assignedIds);
+
+  const commCritQuery = supabase
+    .from('community_items')
+    .select('id', { count: 'exact', head: true })
+    .not('critical_type', 'is', null)
+    .gte('created_at', since);
+  if (assignedIds) commCritQuery.in('workspace_id', assignedIds);
+
+  const snsCritQuery = supabase
+    .from('sns_items')
+    .select('id', { count: 'exact', head: true })
+    .not('critical_type', 'is', null)
+    .gte('created_at', since);
+  if (assignedIds) snsCritQuery.in('workspace_id', assignedIds);
+
+  const sessionQuery = supabase
+    .from('sessions')
+    .select('workspace_id, report_id, workspaces!inner(company_name)')
+    .eq('status', 'failed')
+    .gte('updated_at', since);
+  if (assignedIds) sessionQuery.in('workspace_id', assignedIds);
+
+  const _tAll = Date.now();
+  const [
+    { data: pipelineRows },
+    { data: riskRows, count: riskCount },
+    newsCrit,
+    commCrit,
+    snsCrit,
+    { data: failedSessions },
+  ] = await Promise.all([
+    pipelineQuery,
+    riskQuery,
+    newsCritQuery,
+    commCritQuery,
+    snsCritQuery,
+    sessionQuery,
+  ]);
+  const _allMs = Date.now() - _tAll;
+
   const failedPipelines: FailedPipelineRun[] = (pipelineRows ?? []).map((r) => ({
     id: r.id as string,
     workspace_id: r.workspace_id as string,
@@ -99,17 +159,6 @@ export async function loadAdminHome(
     error_message: (r.error_message as string | null) ?? null,
   }));
 
-  // B-1. 신고 대행 대기 (status NOT IN resolved/rejected)
-  const riskQuery = supabase
-    .from('risk_reports')
-    .select('id, workspace_id, title, critical_type, requested_at, workspaces!inner(company_name)', {
-      count: 'exact',
-    })
-    .not('status', 'in', '("resolved","rejected")')
-    .order('requested_at', { ascending: false })
-    .limit(5);
-  if (assignedIds) riskQuery.in('workspace_id', assignedIds);
-  const { data: riskRows, count: riskCount } = await riskQuery;
   const pendingRiskReports: PendingRiskReport[] = (riskRows ?? []).map((r) => ({
     id: r.id as string,
     workspace_id: r.workspace_id as string,
@@ -119,46 +168,12 @@ export async function loadAdminHome(
     requested_at: r.requested_at as string,
   }));
 
-  // B-2. 최근 24h 내 등록된 critical 콘텐츠 총합 (news + community + sns)
-  const [newsCrit, commCrit, snsCrit] = await Promise.all([
-    (() => {
-      const q = supabase
-        .from('news_items')
-        .select('id', { count: 'exact', head: true })
-        .not('critical_type', 'is', null)
-        .gte('created_at', since);
-      if (assignedIds) q.in('workspace_id', assignedIds);
-      return q;
-    })(),
-    (() => {
-      const q = supabase
-        .from('community_items')
-        .select('id', { count: 'exact', head: true })
-        .not('critical_type', 'is', null)
-        .gte('created_at', since);
-      if (assignedIds) q.in('workspace_id', assignedIds);
-      return q;
-    })(),
-    (() => {
-      const q = supabase
-        .from('sns_items')
-        .select('id', { count: 'exact', head: true })
-        .not('critical_type', 'is', null)
-        .gte('created_at', since);
-      if (assignedIds) q.in('workspace_id', assignedIds);
-      return q;
-    })(),
-  ]);
   const newCriticalCount = (newsCrit.count ?? 0) + (commCrit.count ?? 0) + (snsCrit.count ?? 0);
 
-  // C. 이상 ws — 최근 24h 에 failed 세션이 있는 ws
-  const sessionQuery = supabase
-    .from('sessions')
-    .select('workspace_id, report_id, workspaces!inner(company_name)')
-    .eq('status', 'failed')
-    .gte('updated_at', since);
-  if (assignedIds) sessionQuery.in('workspace_id', assignedIds);
-  const { data: failedSessions } = await sessionQuery;
+  console.log(
+    `[NAV] loadAdminHome: ${Date.now() - _t0}ms ` +
+    `(scope=${_scopeMs}ms, parallel6=${_allMs}ms)`,
+  );
 
   const alertMap = new Map<string, WorkspaceAlert>();
   for (const row of failedSessions ?? []) {

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -1,17 +1,28 @@
+import { cache } from 'react';
 import { createClient } from '@/lib/supabase/server';
 import type { AuthUser, ProfileRow } from '@/types/auth';
 
-export async function getCurrentUser(): Promise<AuthUser | null> {
+// React.cache 로 같은 request 내 중복 호출 방지 (layout + page + 등에서 매번 호출돼도 1회만 실행).
+export const getCurrentUser = cache(async (): Promise<AuthUser | null> => {
+  const _t0 = Date.now();
   const supabase = await createClient();
+  const _tAuth0 = Date.now();
   const { data: { user } } = await supabase.auth.getUser();
+  const _authMs = Date.now() - _tAuth0;
 
-  if (!user) return null;
+  if (!user) {
+    console.log(`[NAV] getCurrentUser: ${Date.now() - _t0}ms (auth=${_authMs}ms, no-user)`);
+    return null;
+  }
 
+  const _tProfile0 = Date.now();
   const { data: profile } = await supabase
     .from('user_profiles')
     .select('*')
     .eq('id', user.id)
     .single<ProfileRow>();
+  const _profileMs = Date.now() - _tProfile0;
+  console.log(`[NAV] getCurrentUser: ${Date.now() - _t0}ms (auth=${_authMs}ms, profile=${_profileMs}ms)`);
 
   if (profile) {
     return {
@@ -35,4 +46,4 @@ export async function getCurrentUser(): Promise<AuthUser | null> {
     createdAt: user.created_at,
     updatedAt: user.created_at,
   };
-}
+});

--- a/src/lib/supabase/middleware.ts
+++ b/src/lib/supabase/middleware.ts
@@ -5,6 +5,8 @@ import type { Database } from '@/types/database.types';
 import { resolveUserReportPath } from '@/lib/auth/resolveLandingPath';
 
 export async function updateSession(request: NextRequest) {
+  const _navT0 = Date.now();
+  const _navPath = request.nextUrl.pathname;
   // /report-pdf — Playwright headless 가 URL 토큰(?at/?rt) 으로 자체 setSession 하므로
   // middleware 의 cookie 기반 인증 검사를 통째로 우회. (matcher negative lookahead 가
   // 일부 환경에서 안 먹어 코드 레벨 early return 으로 처리)
@@ -35,16 +37,29 @@ export async function updateSession(request: NextRequest) {
     },
   );
 
+  const _authT0 = Date.now();
   const {
     data: { user },
   } = await supabase.auth.getUser();
+  const _authMs = Date.now() - _authT0;
 
   const pathname = request.nextUrl.pathname;
   const isAuthPage = pathname.startsWith('/auth/login') || pathname.startsWith('/auth/signup');
   const isCallback = pathname.startsWith('/auth/callback');
 
+  let _roleMs = 0;
+  let _roleCalls = 0;
+  const _measuredGetRole = async () => {
+    const t = Date.now();
+    const r = await getUserRole(supabase, user!.id);
+    _roleMs += Date.now() - t;
+    _roleCalls += 1;
+    return r;
+  };
+
   // 미인증 사용자 → 로그인 페이지로 리다이렉트
   if (!user && !isAuthPage && !isCallback) {
+    console.log(`[NAV] middleware ${_navPath}: ${Date.now() - _navT0}ms (auth=${_authMs}ms, redirect=login)`);
     const url = request.nextUrl.clone();
     url.pathname = '/auth/login';
     return NextResponse.redirect(url);
@@ -54,7 +69,8 @@ export async function updateSession(request: NextRequest) {
   if (user) {
     // auth 페이지 접근 → 역할에 따라 리다이렉트
     if (isAuthPage) {
-      const role = await getUserRole(supabase, user.id);
+      const role = await _measuredGetRole();
+      console.log(`[NAV] middleware ${_navPath}: ${Date.now() - _navT0}ms (auth=${_authMs}ms, role×${_roleCalls}=${_roleMs}ms, redirect=auth-page)`);
       const url = request.nextUrl.clone();
       url.pathname = role === 'user' ? '/' : '/workspace';
       return NextResponse.redirect(url);
@@ -69,13 +85,15 @@ export async function updateSession(request: NextRequest) {
       pathname.startsWith('/crawl-history');
     const isSuperAdminRoute = pathname.startsWith('/users') || pathname.startsWith('/crawl-history');
     if (isAdminRoute) {
-      const role = await getUserRole(supabase, user.id);
+      const role = await _measuredGetRole();
       if (role === 'user') {
+        console.log(`[NAV] middleware ${_navPath}: ${Date.now() - _navT0}ms (auth=${_authMs}ms, role×${_roleCalls}=${_roleMs}ms, redirect=admin-block)`);
         const url = request.nextUrl.clone();
         url.pathname = '/';
         return NextResponse.redirect(url);
       }
       if (isSuperAdminRoute && role !== 'super_admin') {
+        console.log(`[NAV] middleware ${_navPath}: ${Date.now() - _navT0}ms (auth=${_authMs}ms, role×${_roleCalls}=${_roleMs}ms, redirect=super-admin-block)`);
         const url = request.nextUrl.clone();
         url.pathname = '/';
         return NextResponse.redirect(url);
@@ -85,9 +103,10 @@ export async function updateSession(request: NextRequest) {
     // / (홈) — user 역할은 (app) 레이아웃(관리자 사이드바) 진입 자체를 막고
     // 본인 최신 published report 로 직접 이동. admin/super_admin 은 (app)/page.tsx 가 홈 대시보드 렌더.
     if (pathname === '/') {
-      const role = await getUserRole(supabase, user.id);
+      const role = await _measuredGetRole();
       if (role === 'user') {
         const target = (await resolveUserReportPath(supabase, user.id)) ?? '/no-report';
+        console.log(`[NAV] middleware ${_navPath}: ${Date.now() - _navT0}ms (auth=${_authMs}ms, role×${_roleCalls}=${_roleMs}ms, redirect=user-report)`);
         const url = request.nextUrl.clone();
         url.pathname = target;
         return NextResponse.redirect(url);
@@ -95,6 +114,7 @@ export async function updateSession(request: NextRequest) {
     }
   }
 
+  console.log(`[NAV] middleware ${_navPath}: ${Date.now() - _navT0}ms (auth=${_authMs}ms, role×${_roleCalls}=${_roleMs}ms)`);
   return supabaseResponse;
 }
 


### PR DESCRIPTION
- loadAdminHome 의 5단계 직렬 await(scope→A→B1→B2→C)를 6개 쿼리 Promise.all 한 번에 묶어 가장 느린 쿼리 시간으로 단축
- getCurrentUser 를 React.cache 로 wrap → 같은 request 내 layout/page 중복 호출 1회로
- (app)/loading.tsx 추가 (AdminLoading) → 전환 시 freeze 제거
- 검증용 [NAV] 측정 로그 동반 (middleware/layout/page/loadAdminHome stage)