### PR TITLE
style(report): 주간/월간 헤더 풀폭 accent + 탭바 hover underline 인터랙션

### DIFF
--- a/src/app/(client)/report/[workspaceId]/[reportId]/page.tsx
+++ b/src/app/(client)/report/[workspaceId]/[reportId]/page.tsx
@@ -94,11 +94,9 @@ function ClientReportContent() {
   if (pdfMode && !isDaily) {
     return (
       <div className="lg:min-w-fit">
+        <ReportHeader workspaceId={workspaceId} reportId={reportId} showPdfButton={false} fullWidth />
         <SectionBg color="bg-light" id="section-highlight">
-          <div className="flex flex-col lg:gap-10">
-            <ReportHeader workspaceId={workspaceId} reportId={reportId} showPdfButton={false} />
-            <Highlight workspaceId={workspaceId} reportId={reportId} pdfMode />
-          </div>
+          <Highlight workspaceId={workspaceId} reportId={reportId} pdfMode />
         </SectionBg>
         <SectionBg color="bg-light" id="section-reputation">
           <OnlineReputation workspaceId={workspaceId} reportId={reportId} pdfMode />
@@ -144,9 +142,10 @@ function ClientReportContent() {
   // 탭 모드: ReportHeader 고정 + 선택 섹션만 렌더 (weekly / initial)
   return (
     <div className="lg:min-w-fit">
-      <SectionBg color="bg-light">
-        <ReportHeader workspaceId={workspaceId} reportId={reportId} showPdfButton={false} />
-      </SectionBg>
+      <ReportHeader workspaceId={workspaceId} reportId={reportId} showPdfButton={false} fullWidth />
+
+      {/* 헤더와 탭 사이 여백 — 풀폭 accent 헤더와 시각적 분리 */}
+      <div className="hidden lg:block h-8" style={{ backgroundColor: 'var(--color-bg-light)' }} />
 
       {/* 섹션 탭 — 모든 SectionBg 바깥에 두어 스크롤 전 구간에서 sticky 유효.
           모바일은 MobileFab(ClientShell) 이 섹션 이동을 담당하므로 lg 이상에서만 노출. */}
@@ -163,14 +162,20 @@ function ClientReportContent() {
                   key={s.id}
                   type="button"
                   onClick={() => handleTabClick(s.id)}
-                  className={`lg:flex-1 flex items-center justify-center gap-2 px-4 py-2 text-sm font-semibold border-b-2 -mb-px transition-colors cursor-pointer whitespace-nowrap ${
+                  className={`group relative lg:flex-1 flex items-center justify-center gap-2 px-4 py-3 text-sm font-semibold cursor-pointer whitespace-nowrap transition-colors ${
                     active
-                      ? 'border-slate-700 text-slate-800'
-                      : 'border-transparent text-slate-400 hover:text-slate-600'
+                      ? 'text-bg-accent'
+                      : 'text-slate-400 hover:text-bg-accent'
                   }`}
                 >
-                  <s.Icon size={16} color={active ? '#1E293B' : '#828EA6'} />
+                  <s.Icon size={16} color="currentColor" />
                   {s.label}
+                  <span
+                    aria-hidden
+                    className={`pointer-events-none absolute left-0 right-0 -bottom-px h-0.5 bg-bg-accent origin-center transition-transform duration-300 ease-out ${
+                      active ? 'scale-x-100' : 'scale-x-0 group-hover:scale-x-100'
+                    }`}
+                  />
                 </button>
               );
             })}

--- a/src/components/report/ReportHeader.tsx
+++ b/src/components/report/ReportHeader.tsx
@@ -9,9 +9,15 @@ interface ReportHeaderProps {
   workspaceId: string;
   reportId: string;
   showPdfButton?: boolean;
+  fullWidth?: boolean;
 }
 
-export function ReportHeader({ workspaceId, reportId, showPdfButton = true }: ReportHeaderProps) {
+export function ReportHeader({
+  workspaceId,
+  reportId,
+  showPdfButton = true,
+  fullWidth = false,
+}: ReportHeaderProps) {
   const { data: workspace } = useWorkspaceSuspense(workspaceId);
   const { data: report } = useReportInfoSuspense(reportId);
 
@@ -26,6 +32,45 @@ export function ReportHeader({ workspaceId, reportId, showPdfButton = true }: Re
       : 'SIR Weekly Report';
   const periodTitle = isDaily ? '분석 일자' : '분석 기간';
   const periodValue = isDaily ? periodStart : `${periodStart} ~ ${periodEnd}`;
+
+  if (fullWidth) {
+    return (
+      <div className="w-full bg-bg-accent">
+        <div className="mx-auto w-full lg:w-[1200px] px-4 lg:px-10 py-6 lg:py-10 flex flex-col gap-4 lg:gap-5">
+          <div className="w-full flex justify-between items-center">
+            <p className="text-sm lg:text-base text-white/80 font-semibold">{headerLabel}</p>
+            {showPdfButton && (
+              <Link
+                href={`/report/${workspaceId}/${reportId}`}
+                target="_blank"
+                className="group flex items-center gap-2 text-xs lg:text-sm font-semibold text-white border border-white/30 hover:border-white hover:bg-white/10 px-3 py-1.5 lg:px-4 lg:py-2 rounded-lg transition-all"
+              >
+                보고서 보기
+                <ExternalLink
+                  size={13}
+                  className="group-hover:translate-x-0.5 group-hover:-translate-y-0.5 transition-transform"
+                />
+              </Link>
+            )}
+          </div>
+          <div className="flex flex-col lg:flex-row lg:items-end lg:justify-between gap-3">
+            <h1 className="flex lg:flex-row items-baseline gap-2 font-bold">
+              <span className="text-white text-xl lg:text-[36px]">
+                {workspace?.company_name ?? ''}
+              </span>
+              <span className="text-white/60 text-sm lg:text-[22px]">
+                {workspace?.ticker ?? ''}
+              </span>
+            </h1>
+            <p className="flex flex-col lg:flex-row text-[10px] lg:text-sm">
+              <span className="w-12 lg:w-20 text-white font-bold">{periodTitle}</span>
+              <span className="text-white/80">{periodValue}</span>
+            </p>
+          </div>
+        </div>
+      </div>
+    );
+  }
 
   return (
     <div className="flex flex-col gap-2">


### PR DESCRIPTION
- ReportHeader: fullWidth prop 추가. 사이드바 제외 전체 폭 bg-accent 배너 + 라벨을 카드 안으로 묶음
- page.tsx(주간/월간 탭 모드 + PDF 모드): SectionBg 1200px 제약 밖으로 ReportHeader 분리해 fullWidth 호출
- 탭바: 선택 = text-bg-accent + accent underline, hover = scale-x 슬라이드인 underline, 아이콘은 currentColor 추종
- 헤더↔탭 사이 h-8 여백 추가로 시각적 분리