### PR TITLE
style(client): 보고서 탭 폰트 +2px / 인사이트·히스토리 헤더 톤 통일 / 컨테이너 폭 1240px 정렬

### DIFF
--- a/src/app/(client)/crisis/[workspaceId]/page.tsx
+++ b/src/app/(client)/crisis/[workspaceId]/page.tsx
@@ -130,7 +130,7 @@ export default function CrisisCenterPage() {
 
   return (
     <div className="bg-white">
-      <div className="mx-auto w-full lg:w-[1200px] px-4 lg:px-10 py-6 lg:py-10 flex flex-col gap-6">
+      <div className="mx-auto w-full max-w-[1240px] px-4 lg:px-10 py-6 lg:py-10 flex flex-col gap-6">
         <CrisisHeader companyName={workspace?.company_name} />
 
         {/* 탭 + 기간 필터 — 콘텐츠 컨트롤 한 줄 */}

--- a/src/app/(client)/insights-history/[workspaceId]/page.tsx
+++ b/src/app/(client)/insights-history/[workspaceId]/page.tsx
@@ -3,7 +3,7 @@
 import { useMemo, useState } from 'react';
 import { useParams } from 'next/navigation';
 import Link from 'next/link';
-import { History, ChevronDown, ChevronUp, Sparkles } from 'lucide-react';
+import { ChevronDown, ChevronUp, History, Sparkles } from 'lucide-react';
 import ReactMarkdown from 'react-markdown';
 
 import { useWorkspace } from '@/hooks/workspace/useWorkspaceQuery';
@@ -72,20 +72,19 @@ export default function InsightsHistoryPage() {
 
   return (
     <div className="h-full bg-white overflow-y-auto">
-      <div className="mx-auto w-full max-w-[1080px] px-4 lg:px-10 py-7 lg:py-10 flex flex-col gap-6">
+      <div className="mx-auto w-full max-w-[1240px] px-4 lg:px-10 py-7 lg:py-10 flex flex-col gap-6">
         {/* 헤더 ─────────────────────────────────── */}
-        <header className="flex flex-col gap-1.5">
-          <div className="flex items-center gap-2 text-xs text-slate-400 font-medium">
-            <History size={13} className="text-slate-300" />
-            <span>SIR · Insights History</span>
+        <div className="flex flex-col gap-3 bg-bg-dark px-5 py-5 lg:px-10 lg:py-8 rounded-xl">
+          <div className="flex items-center gap-2.5">
+            <History size={24} className="text-violet-400" />
+            <h1 className="text-xl lg:text-2xl font-bold text-white">
+              {workspace?.company_name ?? '워크스페이스'} 분석 히스토리
+            </h1>
           </div>
-          <h1 className="text-[26px] lg:text-[28px] font-bold tracking-[-0.02em] text-slate-900 leading-[1.2]">
-            {workspace?.company_name ?? '워크스페이스'} 분석 히스토리
-          </h1>
-          <p className="text-[13px] text-slate-500 leading-[1.6] max-w-[860px]">
+          <p className="text-xs lg:text-sm text-text-muted">
             인사이트에서 실행한 AI 분석 기록을 시간순으로 모아 봅니다. 각 항목을 클릭하면 본문이 펼쳐집니다.
           </p>
-        </header>
+        </div>
 
         {/* 필터 ─────────────────────────────────── */}
         <div className="rounded-2xl bg-slate-50/70 border border-slate-200/80 px-4 lg:px-5 py-3.5 flex items-center gap-3 flex-wrap">

--- a/src/app/(client)/monitoring/[workspaceId]/page.tsx
+++ b/src/app/(client)/monitoring/[workspaceId]/page.tsx
@@ -2,7 +2,7 @@
 
 import { useMemo, useState } from 'react';
 import { useParams } from 'next/navigation';
-import { TrendingDown, Activity, MessageSquare, Calendar } from 'lucide-react';
+import { TrendingDown, Activity, MessageSquare, Calendar, LineChart } from 'lucide-react';
 import { useWorkspace } from '@/hooks/workspace/useWorkspaceQuery';
 import {
   useMonitoringDaily,
@@ -240,19 +240,18 @@ export default function MonitoringPage() {
     <div className="h-full bg-white overflow-y-auto">
       <div className="mx-auto w-full max-w-[1240px] px-4 lg:px-10 py-7 lg:py-10 flex flex-col gap-7">
         {/* 헤더 ─────────────────────────────────────────── */}
-        <header className="flex flex-col gap-1.5">
-          <div className="flex items-center gap-2 text-xs text-slate-400 font-medium">
-            <Activity size={13} className="text-slate-300" />
-            <span>SIR · Insight</span>
+        <div className="flex flex-col gap-3 bg-bg-dark px-5 py-5 lg:px-10 lg:py-8 rounded-xl">
+          <div className="flex items-center gap-2.5">
+            <LineChart size={24} className="text-blue-400" />
+            <h1 className="text-xl lg:text-2xl font-bold text-white">
+              {workspace?.company_name ?? '워크스페이스'} 인사이트
+            </h1>
           </div>
-          <h1 className="text-[26px] lg:text-[28px] font-bold tracking-[-0.02em] text-slate-900 leading-[1.2]">
-            {workspace?.company_name ?? '워크스페이스'} 인사이트
-          </h1>
-          <p className="text-[13px] text-slate-500 leading-[1.6] max-w-[860px]">
-            워크스페이스 전체 누적 수치와 최신 주가를 상단에 고정 표시합니다. 아래 프리셋으로 차트의
-            기간 범위를 조정할 수 있습니다.
+          <p className="text-xs lg:text-sm text-text-muted">
+            수집된 온라인 평판 데이터와 주가 간 상관관계를 분석해 효과적인 기업가치 관리를 위한
+            인사이트를 얻을 수 있습니다.
           </p>
-        </header>
+        </div>
 
         {/* KPI (기간 무관) ──────────────────────────────── */}
         <div className="grid grid-cols-2 sm:grid-cols-3 gap-3.5">

--- a/src/app/(client)/report/[workspaceId]/[reportId]/page.tsx
+++ b/src/app/(client)/report/[workspaceId]/[reportId]/page.tsx
@@ -162,7 +162,7 @@ function ClientReportContent() {
                   key={s.id}
                   type="button"
                   onClick={() => handleTabClick(s.id)}
-                  className={`group relative lg:flex-1 flex items-center justify-center gap-2 px-4 py-3 text-sm font-semibold cursor-pointer whitespace-nowrap transition-colors ${
+                  className={`group relative lg:flex-1 flex items-center justify-center gap-2 px-4 py-3 text-base font-semibold cursor-pointer whitespace-nowrap transition-colors ${
                     active
                       ? 'text-bg-accent'
                       : 'text-slate-400 hover:text-bg-accent'


### PR DESCRIPTION
- 보고서 탭 네비 text-sm → text-base
- 인사이트·히스토리 헤더를 위기 대응 센터 스타일(bg-dark + 컬러 아이콘 + 흰 타이틀)로 통일, "SIR · ..." breadcrumb 제거
- 인사이트 설명 문구 교체 (수집 데이터·주가 상관관계 → 기업가치 관리 인사이트)
- 세 페이지 컨테이너 폭을 max-w-[1240px] 로 통일
