### PR TITLE
style(monitoring): 차트 제목 제거 + 헤더 아이콘 칩 + 설명글 스타일 통일

### DIFF
--- a/src/components/chart/monitoring/ChannelVolumePriceChart.tsx
+++ b/src/components/chart/monitoring/ChannelVolumePriceChart.tsx
@@ -100,7 +100,7 @@ export function ChannelVolumePriceChart({
       </div>
 
       <ChartCard
-        title="채널별 수집량과 주가"
+        kind="channel"
         subtitle="뉴스·블로그·유튜브·커뮤니티 중 어디서 많이 언급되는지 주가와 함께 봅니다."
         loading={loading}
         empty={empty}

--- a/src/components/chart/monitoring/PriceVolumeChart.tsx
+++ b/src/components/chart/monitoring/PriceVolumeChart.tsx
@@ -41,7 +41,7 @@ export function PriceVolumeChart({
   const hasPrice = merged.some((d) => d.close != null);
   return (
     <ChartCard
-      title="주가와 일별 수집량"
+      kind="volume"
       subtitle="매일 얼마나 많은 평판 데이터가 쌓였는지 주가와 함께 봅니다."
       loading={loading}
       empty={!hasPrice}

--- a/src/components/chart/monitoring/RiskPriceChart.tsx
+++ b/src/components/chart/monitoring/RiskPriceChart.tsx
@@ -41,7 +41,7 @@ export function RiskPriceChart({
   const empty = merged.every((d) => d.riskTotal === 0);
   return (
     <ChartCard
-      title="리스크 유형과 주가"
+      kind="risk"
       subtitle="명예훼손·욕설·루머·스팸 등 유형별 발생량이 주가와 어떻게 맞물리는지 봅니다."
       loading={loading}
       empty={empty}

--- a/src/components/chart/monitoring/SearchPriceChart.tsx
+++ b/src/components/chart/monitoring/SearchPriceChart.tsx
@@ -42,7 +42,7 @@ export function SearchPriceChart({
   const hasSearch = merged.some((d) => d.searchNaver != null);
   return (
     <ChartCard
-      title="검색 관심도와 주가"
+      kind="search"
       subtitle="네이버 검색량(0–100)이 주가와 어떻게 움직이는지 비교합니다."
       loading={loading}
       empty={!hasPrice && !hasSearch}

--- a/src/components/chart/monitoring/SentimentPriceChart.tsx
+++ b/src/components/chart/monitoring/SentimentPriceChart.tsx
@@ -46,7 +46,7 @@ export function SentimentPriceChart({
   const data = merged.map((d, i) => ({ ...d, ...sentimentSeries[i] }));
   return (
     <ChartCard
-      title="감정 분포와 주가"
+      kind="sentiment"
       subtitle="긍정·중립·부정 비율이 주가와 어떻게 맞물리는지 확인합니다."
       loading={loading}
       empty={empty}

--- a/src/components/chart/monitoring/VolumeSearchChart.tsx
+++ b/src/components/chart/monitoring/VolumeSearchChart.tsx
@@ -29,7 +29,7 @@ export function VolumeSearchChart({ merged, selectedDate, setSelectedDate, loadi
   const empty = !hasSearch && merged.every((d) => d.totalVolume === 0);
   return (
     <ChartCard
-      title="수집량과 검색 관심도"
+      kind="volumeSearch"
       subtitle="외부 관심(검색)과 실제 언급량(수집)이 함께 움직이는지 비교합니다."
       loading={loading}
       empty={empty}

--- a/src/components/chart/monitoring/shared.tsx
+++ b/src/components/chart/monitoring/shared.tsx
@@ -2,6 +2,15 @@
 
 import type { ReactNode } from 'react';
 import { ReferenceLine } from 'recharts';
+import {
+  BarChart3,
+  Network,
+  Smile,
+  ShieldAlert,
+  Search,
+  Activity,
+  type LucideIcon,
+} from 'lucide-react';
 import type { Channel, CriticalType, MonitoringDayPoint } from '@/lib/api/monitoringApi';
 
 // ── 차트 공용 데이터 타입 ─────────────────────────────────────────────────
@@ -202,25 +211,54 @@ export function CandleBar(props: CandleBarProps) {
 }
 
 // ── 차트 카드 wrapper ─────────────────────────────────────────────────────
+export type ChartKind =
+  | 'volume'
+  | 'channel'
+  | 'sentiment'
+  | 'risk'
+  | 'search'
+  | 'volumeSearch';
+
+// 탭별 의미 아이콘 + 액센트 컬러 — 헤더 칩에 사용. (accent 뒤 '14' = 8% 소프트 배경)
+const CHART_BADGE: Record<ChartKind, { icon: LucideIcon; accent: string }> = {
+  volume: { icon: BarChart3, accent: '#10b981' },
+  channel: { icon: Network, accent: '#6366f1' },
+  sentiment: { icon: Smile, accent: '#8b5cf6' },
+  risk: { icon: ShieldAlert, accent: '#f43f5e' },
+  search: { icon: Search, accent: '#f59e0b' },
+  volumeSearch: { icon: Activity, accent: '#0ea5e9' },
+};
+
 export function ChartCard({
-  title,
+  kind,
   subtitle,
   children,
   loading,
   empty,
 }: {
-  title: string;
+  kind?: ChartKind;
   subtitle?: string;
   children: ReactNode;
   loading?: boolean;
   empty?: boolean;
 }) {
+  const badge = kind ? CHART_BADGE[kind] : null;
+  const BadgeIcon = badge?.icon;
   return (
     <div className="rounded-2xl bg-white border border-slate-200/80 p-5 lg:p-6 flex flex-col gap-4 shadow-[0_1px_2px_rgba(15,23,42,0.04)]">
-      <div className="flex flex-col gap-0.5">
-        <h3 className="text-[14px] font-bold text-slate-900 tracking-[-0.005em] m-0">{title}</h3>
-        {subtitle && <p className="text-[11px] text-slate-400 m-0 leading-[1.55]">{subtitle}</p>}
-      </div>
+      {subtitle && (
+        <div className="flex items-center gap-2.5">
+          {badge && BadgeIcon && (
+            <span
+              className="shrink-0 w-9 h-9 rounded-xl flex items-center justify-center"
+              style={{ background: `${badge.accent}14`, color: badge.accent }}
+            >
+              <BadgeIcon size={17} />
+            </span>
+          )}
+          <p className="text-xs lg:text-sm font-normal text-text-muted leading-[1.5] m-0">{subtitle}</p>
+        </div>
+      )}
       {loading ? (
         <div className="h-[260px] rounded-xl bg-slate-50 animate-pulse" />
       ) : empty ? (


### PR DESCRIPTION
탭 라벨이 상세해져 중복되던 차트 제목 6종 제거. ChartCard 헤더에
탭별 의미 아이콘(소프트 배경 칩)을 추가하고 kind 레지스트리로 관리.
설명글은 보고서 ReportSubSection 과 동일한
text-xs lg:text-sm text-text-muted 로 맞춰 톤 통일.
