### PR TITLE
feat: update admin risk management for detected risks

### DIFF
--- a/src/app/(app)/risk-reports/RiskReportsClient.tsx
+++ b/src/app/(app)/risk-reports/RiskReportsClient.tsx
@@ -5,8 +5,8 @@ import { useRouter, usePathname, useSearchParams } from 'next/navigation';
 import { toast } from 'sonner';
 import { createClient } from '@/lib/supabase/client';
 import { Combobox, ComboboxButton, ComboboxInput, ComboboxOption, ComboboxOptions, Listbox, ListboxButton, ListboxOption, ListboxOptions } from '@headlessui/react';
-import { ChevronDown, ChevronLeft, ChevronRight, Check, Paperclip, Download, ShieldAlert } from 'lucide-react';
-import { useWorkspaces, useWorkspaceSubscription } from '@/hooks/workspace/useWorkspaceQuery';
+import { ChevronDown, ChevronLeft, ChevronRight, Check, Paperclip, Download } from 'lucide-react';
+import { useWorkspaces } from '@/hooks/workspace/useWorkspaceQuery';
 import { useRiskReports } from '@/hooks/report/useReportQuery';
 import { useUpdateRiskReport } from '@/hooks/report/useReportMutation';
 import { getErrorMessage } from '@/lib/utils';
@@ -22,27 +22,44 @@ const PAGE_SIZE = 50;
 type SortKey = 'requested_desc' | 'requested_asc' | 'company' | 'status';
 
 const SORT_OPTIONS: { value: SortKey; label: string }[] = [
-  { value: 'requested_desc', label: '신청일 최신순' },
-  { value: 'requested_asc', label: '신청일 오래된순' },
+  { value: 'requested_desc', label: '감지/신청일 최신순' },
+  { value: 'requested_asc', label: '감지/신청일 오래된순' },
   { value: 'company', label: '회사명' },
   { value: 'status', label: '처리 상태' },
 ];
 
 const STATUS_OPTIONS = [
+  { value: 'detected', label: '미처리' },
   { value: 'requested', label: '요청 완료' },
-  { value: 'pending', label: '결과 대기' },
+  { value: 'pending', label: '삭제 처리 중' },
   { value: 'resolved', label: '삭제 완료' },
-  { value: 'rejected', label: '삭제 반려' },
+  { value: 'rejected', label: '삭제 불가' },
 ] as const;
 
 const STATUS_STYLES: Record<string, { label: string; className: string }> = {
-  requested: { label: '요청 완료', className: 'bg-slate-100 text-slate-600' },
-  pending: { label: '결과 대기', className: 'bg-amber-50 text-amber-600' },
+  detected: { label: '미처리', className: 'bg-zinc-100 text-zinc-600' },
+  requested: { label: '요청 완료', className: 'bg-blue-50 text-blue-600' },
+  pending: { label: '삭제 처리 중', className: 'bg-amber-50 text-amber-600' },
   resolved: { label: '삭제 완료', className: 'bg-blue-50 text-blue-600' },
-  rejected: { label: '삭제 반려', className: 'bg-red-50 text-red-600' },
+  rejected: { label: '삭제 불가', className: 'bg-red-50 text-red-600' },
 };
 
+const UNKNOWN_STATUS_STYLE = { label: '알 수 없음', className: 'bg-slate-100 text-slate-600' };
+
+function normalizeStatus(status: string | null | undefined): string {
+  return (status ?? '').trim().toLowerCase();
+}
+
+function getStatusConfig(status: string | null | undefined): { label: string; className: string } {
+  const normalized = normalizeStatus(status);
+  return STATUS_STYLES[normalized] ?? {
+    ...UNKNOWN_STATUS_STYLE,
+    label: status?.trim() || UNKNOWN_STATUS_STYLE.label,
+  };
+}
+
 const PLATFORM_LABELS: Record<string, string> = {
+  naver_news: '뉴스',
   naver_blog: '블로그',
   youtube: '유튜브',
   naver_stock: '종토방',
@@ -123,19 +140,20 @@ function WorkspaceCombobox({
 // ── 상세 모달 ──
 
 function DetailModal({ report, onClose }: { report: RiskReport; onClose: () => void }) {
-  const [status, setStatus] = useState(report.status);
+  const initialStatus = normalizeStatus(report.status);
+  const [status, setStatus] = useState(initialStatus);
   const [adminNote, setAdminNote] = useState(report.admin_note ?? '');
   const [showConfirm, setShowConfirm] = useState(false);
 
   const update = useUpdateRiskReport(report.workspace_id);
   const saving = update.isPending;
 
-  const statusChanged = status !== report.status;
+  const statusChanged = status !== initialStatus;
   const noteChanged = adminNote !== (report.admin_note ?? '');
   const hasChanges = statusChanged || noteChanged;
 
-  const oldStatusLabel = STATUS_STYLES[report.status]?.label ?? report.status;
-  const newStatusLabel = STATUS_OPTIONS.find((s) => s.value === status)?.label ?? status;
+  const oldStatusLabel = getStatusConfig(report.status).label;
+  const newStatusLabel = getStatusConfig(status).label;
 
   const doSave = async () => {
     try {
@@ -161,7 +179,7 @@ function DetailModal({ report, onClose }: { report: RiskReport; onClose: () => v
     <Modal
       open
       onClose={onClose}
-      title="신고 대행 요청 상세"
+      title="리스크 항목 상세"
       size="lg"
       footer={
         <Button onClick={handleSaveClick} disabled={!hasChanges || saving}>
@@ -170,7 +188,7 @@ function DetailModal({ report, onClose }: { report: RiskReport; onClose: () => v
       }
     >
       <div className="flex flex-col gap-2">
-        <label className="text-sm font-semibold text-text-dark">신고 게시물</label>
+        <label className="text-sm font-semibold text-text-dark">리스크 콘텐츠</label>
         <div className="bg-bg-blue rounded-lg px-4 py-3">
           <a href={report.link} target="_blank" rel="noopener noreferrer" className="text-sm text-text-accent hover:underline">
             {report.title}
@@ -190,12 +208,12 @@ function DetailModal({ report, onClose }: { report: RiskReport; onClose: () => v
       </div>
 
       <div className="flex flex-col gap-1">
-        <span className="text-xs font-semibold text-text-muted">신고 사유</span>
+        <span className="text-xs font-semibold text-text-muted">사유</span>
         <span className="text-sm text-text-dark">{report.reason}</span>
       </div>
 
       <div className="flex flex-col gap-1">
-        <span className="text-xs font-semibold text-text-muted">신고 근거</span>
+        <span className="text-xs font-semibold text-text-muted">근거</span>
         <div className="bg-bg-light rounded-lg px-4 py-3 text-sm text-text-dark whitespace-pre-line">
           {report.evidence}
         </div>
@@ -335,13 +353,6 @@ export function RiskReportsClient({ assignedIds }: RiskReportsClientProps) {
     selectedReportId || undefined,
   );
 
-  // 선택된 워크스페이스의 아머 활성 여부. 전체(빈 selectedWsId)면 체크 스킵.
-  const { data: selectedSub } = useWorkspaceSubscription(selectedWsId);
-  const selectedHasArmor = selectedWsId
-    ? selectedSub?.has_armor ?? null  // null: 로딩 중
-    : true; // 전체는 게이트 안 함
-  const showArmorEmpty = selectedWsId !== '' && selectedHasArmor === false;
-
   // admin 은 배정받은 ws 의 risk 만 보이도록 클라이언트에서 한 번 더 필터
   const riskReports = useMemo(() => {
     if (assignedIds === null) return rawRiskReports;
@@ -374,7 +385,7 @@ export function RiskReportsClient({ assignedIds }: RiskReportsClientProps) {
   const filtered = useMemo(() => {
     let list = riskReports ?? [];
     if (statusFilter !== 'all') {
-      list = list.filter((r) => r.status === statusFilter);
+      list = list.filter((r) => normalizeStatus(r.status) === statusFilter);
     }
     return list;
   }, [riskReports, statusFilter]);
@@ -390,7 +401,7 @@ export function RiskReportsClient({ assignedIds }: RiskReportsClientProps) {
         case 'company':
           return (wsMap.get(a.workspace_id) ?? '').localeCompare(wsMap.get(b.workspace_id) ?? '');
         case 'status':
-          return a.status.localeCompare(b.status);
+          return getStatusConfig(a.status).label.localeCompare(getStatusConfig(b.status).label);
         default:
           return 0;
       }
@@ -472,7 +483,7 @@ export function RiskReportsClient({ assignedIds }: RiskReportsClientProps) {
             {STATUS_FILTERS.map((f) => {
               const count = f.key === 'all'
                 ? (riskReports ?? []).length
-                : (riskReports ?? []).filter((r) => r.status === f.key).length;
+                : (riskReports ?? []).filter((r) => normalizeStatus(r.status) === f.key).length;
               const active = statusFilter === f.key;
               return (
                 <button
@@ -488,65 +499,54 @@ export function RiskReportsClient({ assignedIds }: RiskReportsClientProps) {
               );
             })}
           </div>
-          {/* 헤더 (데스크톱만) — 탭과 함께 flex-1 overflow-y-auto 위에 위치해 자동 고정 */}
-          <div className="hidden lg:grid bg-white grid-cols-[8%_10%_8%_8%_1fr_12%] border-b border-slate-100 py-3 px-4 text-xs font-semibold text-slate-500 text-center shrink-0">
-            <div>신고일</div>
-            <div>회사명</div>
-            <div>채널명</div>
-            <div>신고 사유</div>
-            <div className="text-left pl-2">세부 내용</div>
-            <div>상태</div>
-          </div>
+          {/* 스크롤 영역: 헤더와 바디가 같은 스크롤바 폭을 공유해야 컬럼 정렬이 어긋나지 않는다. */}
+          <div className="flex-1 overflow-y-auto [scrollbar-gutter:stable]">
+            {/* 헤더 (데스크톱만) — 같은 스크롤 컨테이너 안에서 sticky 고정 */}
+            <div className="hidden lg:grid sticky top-0 z-10 bg-white grid-cols-[8%_10%_8%_8%_1fr_12%] border-b border-slate-100 py-3 px-4 text-xs font-semibold text-slate-500 text-center">
+              <div>감지/요청일</div>
+              <div>회사명</div>
+              <div>채널명</div>
+              <div>사유</div>
+              <div className="text-left pl-2">세부 내용</div>
+              <div>상태</div>
+            </div>
 
-          {/* 바디 */}
-          {isLoading ? (
-            <div className="flex-1 flex items-center justify-center">
-              <p className="text-xs text-text-muted">불러오는 중...</p>
-            </div>
-          ) : showArmorEmpty ? (
-            <div className="flex-1 flex items-center justify-center px-6">
-              <div className="flex flex-col items-center gap-2 text-center py-10">
-                <ShieldAlert size={28} className="text-bg-accent" />
-                <p className="text-sm font-semibold text-text-dark">
-                  이 워크스페이스는 아머 서비스를 이용하고 있지 않습니다.
-                </p>
-                <p className="text-xs text-text-muted leading-relaxed">
-                  아머(신고 대행) 미구독 워크스페이스는 신고 대행 요청을 등록할 수 없습니다.
-                </p>
+            {isLoading ? (
+              <div className="min-h-48 flex items-center justify-center">
+                <p className="text-xs text-text-muted">불러오는 중...</p>
               </div>
-            </div>
-          ) : sorted.length === 0 ? (
-            <div className="flex-1 flex items-center justify-center px-6 text-center">
-              {(riskReports?.length ?? 0) === 0 ? (
-                <p className="text-xs text-text-muted">
-                  {selectedReportId
-                    ? '선택한 보고서에 등록된 신고 대행 요청이 없습니다.'
-                    : selectedWsId
-                      ? '이 워크스페이스에 등록된 신고 대행 요청이 없습니다.'
-                      : '신고 대행 요청이 없습니다.'}
-                </p>
-              ) : (
-                <div className="flex flex-col items-center gap-2">
+            ) : sorted.length === 0 ? (
+              <div className="min-h-48 flex items-center justify-center px-6 text-center">
+                {(riskReports?.length ?? 0) === 0 ? (
                   <p className="text-xs text-text-muted">
-                    <span className="font-semibold text-slate-700">
-                      {STATUS_FILTERS.find((s) => s.key === statusFilter)?.label}
-                    </span>
-                    {' '}상태의 신고가 없습니다.
+                    {selectedReportId
+                      ? '선택한 보고서에 등록된 리스크 항목이 없습니다.'
+                      : selectedWsId
+                        ? '이 워크스페이스에 등록된 리스크 항목이 없습니다.'
+                        : '리스크 항목이 없습니다.'}
                   </p>
-                  <button
-                    type="button"
-                    onClick={() => handleStatusFilterChange('all')}
-                    className="text-[11px] font-semibold text-slate-600 bg-slate-100 hover:bg-slate-200 px-2.5 py-1 rounded-md transition-colors cursor-pointer"
-                  >
-                    전체 보기
-                  </button>
-                </div>
-              )}
-            </div>
-          ) : (
-            <div className="flex-1 overflow-y-auto">
+                ) : (
+                  <div className="flex flex-col items-center gap-2">
+                    <p className="text-xs text-text-muted">
+                      <span className="font-semibold text-slate-700">
+                        {STATUS_FILTERS.find((s) => s.key === statusFilter)?.label}
+                      </span>
+                      {' '}상태의 리스크 항목이 없습니다.
+                    </p>
+                    <button
+                      type="button"
+                      onClick={() => handleStatusFilterChange('all')}
+                      className="text-[11px] font-semibold text-slate-600 bg-slate-100 hover:bg-slate-200 px-2.5 py-1 rounded-md transition-colors cursor-pointer"
+                    >
+                      전체 보기
+                    </button>
+                  </div>
+                )}
+              </div>
+            ) : (
+              <>
               {paged.map((rr) => {
-                const statusCfg = STATUS_STYLES[rr.status] ?? { label: rr.status, className: 'bg-slate-100 text-slate-600' };
+                const statusCfg = getStatusConfig(rr.status);
                 const requestedLabel = rr.requested_at?.slice(5, 10).replace(/-/g, '.') ?? '';
                 const companyLabel = wsMap.get(rr.workspace_id) ?? '';
                 const platformLabel = PLATFORM_LABELS[rr.platform_id] ?? rr.platform_id;
@@ -620,8 +620,9 @@ export function RiskReportsClient({ assignedIds }: RiskReportsClientProps) {
                   </div>
                 );
               })}
-            </div>
-          )}
+              </>
+            )}
+          </div>
 
           {/* 페이지네이션 + 총 건수 */}
           <div className="flex items-center justify-between gap-3 px-4 py-2 shrink-0 border-t border-slate-50">

--- a/src/app/(app)/risk-reports/RiskReportsClient.tsx
+++ b/src/app/(app)/risk-reports/RiskReportsClient.tsx
@@ -46,6 +46,13 @@ const STATUS_STYLES: Record<string, { label: string; className: string }> = {
 
 const UNKNOWN_STATUS_STYLE = { label: '알 수 없음', className: 'bg-slate-100 text-slate-600' };
 
+const CRITICAL_TYPE_LABELS: Record<string, string> = {
+  defamation: '명예훼손',
+  insult: '욕설/비방',
+  rumor: '루머',
+  spam: '스팸',
+};
+
 function normalizeStatus(status: string | null | undefined): string {
   return (status ?? '').trim().toLowerCase();
 }
@@ -56,6 +63,10 @@ function getStatusConfig(status: string | null | undefined): { label: string; cl
     ...UNKNOWN_STATUS_STYLE,
     label: status?.trim() || UNKNOWN_STATUS_STYLE.label,
   };
+}
+
+function getCriticalTypeLabel(type: string): string {
+  return CRITICAL_TYPE_LABELS[type] ?? type;
 }
 
 const PLATFORM_LABELS: Record<string, string> = {
@@ -154,6 +165,7 @@ function DetailModal({ report, onClose }: { report: RiskReport; onClose: () => v
 
   const oldStatusLabel = getStatusConfig(report.status).label;
   const newStatusLabel = getStatusConfig(status).label;
+  const criticalTypeLabel = getCriticalTypeLabel(report.critical_type);
 
   const doSave = async () => {
     try {
@@ -203,7 +215,7 @@ function DetailModal({ report, onClose }: { report: RiskReport; onClose: () => v
         </div>
         <div className="flex flex-col gap-1">
           <span className="text-xs font-semibold text-text-muted">리스크 유형</span>
-          <span className="text-sm text-text-dark">{report.critical_type}</span>
+          <span className="text-sm text-text-dark">{criticalTypeLabel}</span>
         </div>
       </div>
 

--- a/src/app/(client)/crisis/[workspaceId]/page.tsx
+++ b/src/app/(client)/crisis/[workspaceId]/page.tsx
@@ -103,12 +103,14 @@ export default function CrisisCenterPage() {
   const deleteMutation = useDeleteRiskReport(workspaceId);
 
 
-  // requested = 사용자가 요청만 한 상태(취소 가능). 그 외(pending/resolved/rejected) = admin 처리 시작 → 취소 불가.
+  // detected = AI가 자동 감지만 한 상태라 사용자가 아직 신고 대행을 요청한 것으로 보지 않는다.
+  // requested = 사용자가 요청만 한 상태(취소 가능). pending/resolved/rejected = admin 처리 시작 → 취소 불가.
   const { reportedSourceIds, riskReportBySourceId, processedSourceIds } = useMemo(() => {
     const ids = new Set<string>();
     const map = new Map<string, string>();
     const processed = new Set<string>();
     for (const rr of riskReports ?? []) {
+      if (rr.status === 'detected') continue;
       ids.add(rr.source_id);
       map.set(rr.source_id, rr.id);
       if (rr.status !== 'requested') processed.add(rr.source_id);
@@ -116,10 +118,12 @@ export default function CrisisCenterPage() {
     return { reportedSourceIds: ids, riskReportBySourceId: map, processedSourceIds: processed };
   }, [riskReports]);
 
-  // 리스크 콘텐츠 처리 결과: 신고 등록 이후 모든 단계
-  // (requested 요청 완료 / pending 결과 대기 / resolved 삭제 완료 / rejected 삭제 반려)
+  // 리스크 콘텐츠 처리 결과: 신고 등록 이후 모든 단계만 노출.
+  // detected 는 관리자 리스크 관리용 자동 감지 상태라 고객의 신고 요청/처리 결과로 보지 않는다.
+  // (requested 요청 완료 / pending 삭제 처리 중 / resolved 삭제 완료 / rejected 삭제 불가)
   const processedReports = useMemo(() => {
     return (riskReports ?? [])
+      .filter((rr) => rr.status !== 'detected')
       .slice()
       .sort((a, b) =>
         (b.resolved_at ?? b.requested_at ?? '').localeCompare(a.resolved_at ?? a.requested_at ?? '')

--- a/src/app/api/risk-report/[id]/route.ts
+++ b/src/app/api/risk-report/[id]/route.ts
@@ -1,0 +1,139 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { createClient as createServerClient } from '@/lib/supabase/server';
+import { createClient as createAdminClient } from '@supabase/supabase-js';
+import type { Database } from '@/types/database.types';
+
+export const dynamic = 'force-dynamic';
+
+const RISK_STATUS_VALUES = new Set(['detected', 'requested', 'pending', 'resolved', 'rejected']);
+
+type RiskReportUpdate = Database['public']['Tables']['risk_reports']['Update'];
+
+function createAdmin() {
+  return createAdminClient<Database>(
+    process.env.NEXT_PUBLIC_SUPABASE_URL!,
+    process.env.SUPABASE_SERVICE_ROLE_KEY!,
+    { auth: { persistSession: false, autoRefreshToken: false } },
+  );
+}
+
+async function getCaller() {
+  const supabase = await createServerClient();
+  const { data: { user } } = await supabase.auth.getUser();
+  return user;
+}
+
+export async function PATCH(
+  request: NextRequest,
+  { params }: { params: Promise<{ id: string }> },
+) {
+  const caller = await getCaller();
+  if (!caller) {
+    return NextResponse.json({ detail: '인증 필요' }, { status: 401 });
+  }
+
+  const { id } = await params;
+  if (!id) {
+    return NextResponse.json({ detail: 'risk report id 필수' }, { status: 400 });
+  }
+
+  const admin = createAdmin();
+
+  const { data: profile, error: profileError } = await admin
+    .from('user_profiles')
+    .select('role')
+    .eq('id', caller.id)
+    .maybeSingle();
+  if (profileError) {
+    return NextResponse.json({ detail: profileError.message }, { status: 500 });
+  }
+  if (profile?.role !== 'super_admin' && profile?.role !== 'admin') {
+    return NextResponse.json({ detail: '관리자 권한 필요' }, { status: 403 });
+  }
+
+  const { data: riskReport, error: riskError } = await admin
+    .from('risk_reports')
+    .select('id, workspace_id, file_urls')
+    .eq('id', id)
+    .maybeSingle();
+  if (riskError) {
+    return NextResponse.json({ detail: riskError.message }, { status: 500 });
+  }
+  if (!riskReport) {
+    return NextResponse.json({ detail: '리스크 항목을 찾을 수 없습니다' }, { status: 404 });
+  }
+
+  if (profile.role === 'admin') {
+    const { data: membership, error: memberError } = await admin
+      .from('workspace_members')
+      .select('id')
+      .eq('workspace_id', riskReport.workspace_id)
+      .eq('profile_id', caller.id)
+      .limit(1)
+      .maybeSingle();
+    if (memberError) {
+      return NextResponse.json({ detail: memberError.message }, { status: 500 });
+    }
+    if (!membership) {
+      return NextResponse.json({ detail: '해당 워크스페이스에 접근 권한이 없습니다' }, { status: 403 });
+    }
+  }
+
+  let body: unknown;
+  try {
+    body = await request.json();
+  } catch {
+    return NextResponse.json({ detail: 'JSON body가 필요합니다' }, { status: 400 });
+  }
+  if (!body || typeof body !== 'object' || Array.isArray(body)) {
+    return NextResponse.json({ detail: '잘못된 요청 body입니다' }, { status: 400 });
+  }
+
+  const input = body as { status?: unknown; admin_note?: unknown };
+  const update: RiskReportUpdate = {};
+
+  if ('status' in input) {
+    if (typeof input.status !== 'string') {
+      return NextResponse.json({ detail: 'status는 문자열이어야 합니다' }, { status: 400 });
+    }
+    const status = input.status.trim().toLowerCase();
+    if (!RISK_STATUS_VALUES.has(status)) {
+      return NextResponse.json({ detail: '허용되지 않은 status입니다' }, { status: 400 });
+    }
+    update.status = status;
+    update.resolved_at = status === 'resolved' || status === 'rejected'
+      ? new Date().toISOString()
+      : null;
+
+    if ((status === 'resolved' || status === 'rejected') && riskReport.file_urls.length > 0) {
+      const { error: storageError } = await admin.storage
+        .from('risk-attachments')
+        .remove(riskReport.file_urls);
+      if (storageError) {
+        return NextResponse.json({ detail: storageError.message }, { status: 500 });
+      }
+      update.file_urls = [];
+    }
+  }
+
+  if ('admin_note' in input) {
+    if (input.admin_note !== null && typeof input.admin_note !== 'string') {
+      return NextResponse.json({ detail: 'admin_note는 문자열 또는 null이어야 합니다' }, { status: 400 });
+    }
+    update.admin_note = input.admin_note ?? null;
+  }
+
+  if (Object.keys(update).length === 0) {
+    return NextResponse.json({ detail: '업데이트할 필드가 없습니다' }, { status: 400 });
+  }
+
+  const { error: updateError } = await admin
+    .from('risk_reports')
+    .update(update)
+    .eq('id', id);
+  if (updateError) {
+    return NextResponse.json({ detail: updateError.message }, { status: 500 });
+  }
+
+  return NextResponse.json({ status: 'updated' });
+}

--- a/src/app/api/risk-report/request/route.ts
+++ b/src/app/api/risk-report/request/route.ts
@@ -1,0 +1,263 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { createClient as createServerClient } from '@/lib/supabase/server';
+import { createClient as createAdminClient } from '@supabase/supabase-js';
+import type { Database } from '@/types/database.types';
+
+export const dynamic = 'force-dynamic';
+
+type RiskSourceTable = 'news_items' | 'community_items' | 'sns_items';
+type CriticalType = Database['public']['Enums']['critical_type'];
+type RiskReportInsert = Database['public']['Tables']['risk_reports']['Insert'];
+type RiskReportUpdate = Database['public']['Tables']['risk_reports']['Update'];
+
+type SourceRow = {
+  id: string;
+  workspace_id: string;
+  session_id: string | null;
+  platform_id: string;
+  title: string;
+  link: string;
+  critical_type: CriticalType | null;
+  critical_reason: string | null;
+  is_relevant: boolean | null;
+};
+
+const TABLE_BY_PLATFORM: Record<string, RiskSourceTable> = {
+  naver_news: 'news_items',
+  naver_blog: 'sns_items',
+  youtube: 'sns_items',
+  naver_stock: 'community_items',
+  dcinside: 'community_items',
+};
+
+function createAdmin() {
+  return createAdminClient<Database>(
+    process.env.NEXT_PUBLIC_SUPABASE_URL!,
+    process.env.SUPABASE_SERVICE_ROLE_KEY!,
+    { auth: { persistSession: false, autoRefreshToken: false } },
+  );
+}
+
+async function getCaller() {
+  const supabase = await createServerClient();
+  const { data: { user } } = await supabase.auth.getUser();
+  return user;
+}
+
+function isStringArray(value: unknown): value is string[] {
+  return Array.isArray(value) && value.every((item) => typeof item === 'string');
+}
+
+async function fetchSourceItem(
+  admin: ReturnType<typeof createAdmin>,
+  table: RiskSourceTable,
+  sourceId: string,
+): Promise<{ data: SourceRow | null; error: Error | null }> {
+  const select = 'id, workspace_id, session_id, platform_id, title, link, critical_type, critical_reason, is_relevant';
+  const result = await admin.from(table).select(select).eq('id', sourceId).maybeSingle();
+  return {
+    data: result.data as SourceRow | null,
+    error: result.error,
+  };
+}
+
+export async function POST(request: NextRequest) {
+  const caller = await getCaller();
+  if (!caller) {
+    return NextResponse.json({ detail: '인증 필요' }, { status: 401 });
+  }
+
+  let body: unknown;
+  try {
+    body = await request.json();
+  } catch {
+    return NextResponse.json({ detail: 'JSON body가 필요합니다' }, { status: 400 });
+  }
+  if (!body || typeof body !== 'object' || Array.isArray(body)) {
+    return NextResponse.json({ detail: '잘못된 요청 body입니다' }, { status: 400 });
+  }
+
+  const input = body as {
+    workspace_id?: unknown;
+    report_id?: unknown;
+    source_id?: unknown;
+    platform_id?: unknown;
+    reason?: unknown;
+    evidence?: unknown;
+    file_urls?: unknown;
+  };
+
+  if (
+    typeof input.workspace_id !== 'string' ||
+    typeof input.report_id !== 'string' ||
+    typeof input.source_id !== 'string' ||
+    typeof input.platform_id !== 'string' ||
+    typeof input.reason !== 'string' ||
+    typeof input.evidence !== 'string' ||
+    !isStringArray(input.file_urls)
+  ) {
+    return NextResponse.json({ detail: '필수 요청값이 올바르지 않습니다' }, { status: 400 });
+  }
+
+  const workspaceId = input.workspace_id;
+  const reportId = input.report_id;
+  const sourceId = input.source_id;
+  const platformId = input.platform_id;
+  const fileUrls = input.file_urls;
+  const sourceTable = TABLE_BY_PLATFORM[platformId];
+  if (!sourceTable) {
+    return NextResponse.json({ detail: `알 수 없는 platform: ${platformId}` }, { status: 400 });
+  }
+  if (!fileUrls.every((url) => url.startsWith(`${workspaceId}/`))) {
+    return NextResponse.json({ detail: '첨부 파일 경로가 올바르지 않습니다' }, { status: 400 });
+  }
+
+  const admin = createAdmin();
+
+  const { data: profile, error: profileError } = await admin
+    .from('user_profiles')
+    .select('role')
+    .eq('id', caller.id)
+    .maybeSingle();
+  if (profileError) {
+    return NextResponse.json({ detail: profileError.message }, { status: 500 });
+  }
+
+  const { data: membership, error: memberError } = await admin
+    .from('workspace_members')
+    .select('id')
+    .eq('workspace_id', workspaceId)
+    .eq('profile_id', caller.id)
+    .limit(1)
+    .maybeSingle();
+  if (memberError) {
+    return NextResponse.json({ detail: memberError.message }, { status: 500 });
+  }
+  if (profile?.role !== 'super_admin' && !membership) {
+    return NextResponse.json({ detail: '해당 워크스페이스에 접근 권한이 없습니다' }, { status: 403 });
+  }
+
+  const now = new Date().toISOString();
+  const { data: subscription, error: subscriptionError } = await admin
+    .from('subscriptions')
+    .select('id')
+    .eq('workspace_id', workspaceId)
+    .eq('has_armor', true)
+    .lte('started_at', now)
+    .gt('ended_at', now)
+    .limit(1)
+    .maybeSingle();
+  if (subscriptionError) {
+    return NextResponse.json({ detail: subscriptionError.message }, { status: 500 });
+  }
+  if (!subscription) {
+    return NextResponse.json({ detail: '아머 서비스가 활성화된 워크스페이스만 신고 대행 요청이 가능합니다' }, { status: 403 });
+  }
+
+  const { data: report, error: reportError } = await admin
+    .from('reports')
+    .select('id, workspace_id, type')
+    .eq('id', reportId)
+    .eq('workspace_id', workspaceId)
+    .maybeSingle();
+  if (reportError) {
+    return NextResponse.json({ detail: reportError.message }, { status: 500 });
+  }
+  if (!report) {
+    return NextResponse.json({ detail: '보고서를 찾을 수 없습니다' }, { status: 404 });
+  }
+  if (report.type === 'initial') {
+    return NextResponse.json({ detail: '초기 보고서 리스크는 신고 대행 요청할 수 없습니다' }, { status: 400 });
+  }
+
+  const { data: sourceItem, error: sourceError } = await fetchSourceItem(admin, sourceTable, sourceId);
+  if (sourceError) {
+    return NextResponse.json({ detail: sourceError.message }, { status: 500 });
+  }
+  if (!sourceItem) {
+    return NextResponse.json({ detail: '리스크 콘텐츠를 찾을 수 없습니다' }, { status: 404 });
+  }
+  if (sourceItem.workspace_id !== workspaceId || sourceItem.platform_id !== platformId) {
+    return NextResponse.json({ detail: '리스크 콘텐츠가 요청 워크스페이스와 일치하지 않습니다' }, { status: 400 });
+  }
+  if (!sourceItem.session_id) {
+    return NextResponse.json({ detail: '리스크 콘텐츠의 세션 정보가 없습니다' }, { status: 400 });
+  }
+  if (sourceItem.is_relevant !== true || !sourceItem.critical_type) {
+    return NextResponse.json({ detail: '신고 가능한 리스크 콘텐츠가 아닙니다' }, { status: 400 });
+  }
+
+  const { data: session, error: sessionError } = await admin
+    .from('sessions')
+    .select('id, workspace_id, report_id')
+    .eq('id', sourceItem.session_id)
+    .eq('workspace_id', workspaceId)
+    .maybeSingle();
+  if (sessionError) {
+    return NextResponse.json({ detail: sessionError.message }, { status: 500 });
+  }
+  if (!session || session.report_id !== reportId) {
+    return NextResponse.json({ detail: '리스크 콘텐츠가 요청 보고서에 속하지 않습니다' }, { status: 400 });
+  }
+
+  const { data: existing, error: existingError } = await admin
+    .from('risk_reports')
+    .select('id, status')
+    .eq('source_table', sourceTable)
+    .eq('source_id', sourceId)
+    .maybeSingle();
+  if (existingError) {
+    return NextResponse.json({ detail: existingError.message }, { status: 500 });
+  }
+
+  const common = {
+    workspace_id: workspaceId,
+    report_id: reportId,
+    platform_id: platformId,
+    title: sourceItem.title || '(제목 없음)',
+    link: sourceItem.link || '#',
+    critical_type: sourceItem.critical_type,
+    reason: input.reason,
+    evidence: input.evidence,
+    file_urls: fileUrls,
+    status: 'requested',
+    requested_at: now,
+    resolved_at: null,
+  } satisfies RiskReportUpdate;
+
+  if (existing) {
+    if (existing.status !== 'detected') {
+      return NextResponse.json(
+        { detail: '이미 신고 대행 요청이 등록되어 있습니다', id: existing.id, status: existing.status },
+        { status: 409 },
+      );
+    }
+
+    const { error: updateError } = await admin
+      .from('risk_reports')
+      .update(common)
+      .eq('id', existing.id)
+      .eq('status', 'detected');
+    if (updateError) {
+      return NextResponse.json({ detail: updateError.message }, { status: 500 });
+    }
+    return NextResponse.json({ id: existing.id, status: 'requested', upgraded: true });
+  }
+
+  const insertPayload = {
+    ...common,
+    source_table: sourceTable,
+    source_id: sourceId,
+  } satisfies RiskReportInsert;
+
+  const { data: inserted, error: insertError } = await admin
+    .from('risk_reports')
+    .insert(insertPayload)
+    .select('id')
+    .single();
+  if (insertError) {
+    return NextResponse.json({ detail: insertError.message }, { status: 500 });
+  }
+
+  return NextResponse.json({ id: inserted.id, status: 'requested', upgraded: false });
+}

--- a/src/components/crisis/CrisisProcessedReports.tsx
+++ b/src/components/crisis/CrisisProcessedReports.tsx
@@ -8,9 +8,9 @@ import type { RiskReport } from '@/types/report';
 
 const STATUS_STYLES: Record<string, { label: string; className: string }> = {
   requested: { label: '요청 완료', className: 'bg-slate-100 text-slate-600' },
-  pending: { label: '결과 대기', className: 'bg-amber-50 text-amber-600' },
+  pending: { label: '삭제 처리 중', className: 'bg-amber-50 text-amber-600' },
   resolved: { label: '삭제 완료', className: 'bg-blue-50 text-blue-600' },
-  rejected: { label: '삭제 반려', className: 'bg-red-50 text-red-600' },
+  rejected: { label: '삭제 불가', className: 'bg-red-50 text-red-600' },
 };
 
 const PLATFORM_LABELS: Record<string, string> = {

--- a/src/components/report/RiskContent.tsx
+++ b/src/components/report/RiskContent.tsx
@@ -39,6 +39,9 @@ export function RiskContent({ workspaceId, reportId, editable = false, allowRepo
     const map = new Map<string, string>();
     const processed = new Set<string>();
     for (const rr of riskReports) {
+      // detected 는 관리자 리스크 관리용 자동 감지 상태이며,
+      // 사용자가 신고 대행을 요청한 상태로 보지 않는다.
+      if (rr.status === 'detected') continue;
       ids.add(rr.source_id);
       map.set(rr.source_id, rr.id);
       if (rr.status !== 'requested') processed.add(rr.source_id);

--- a/src/components/report/risk-content/RiskResultTable.tsx
+++ b/src/components/report/risk-content/RiskResultTable.tsx
@@ -7,7 +7,7 @@ import { EmptyState } from '@/components/ui/EmptyState';
 
 const STATUS_STYLES: Record<string, { label: string; className: string }> = {
   resolved: { label: '삭제 완료', className: 'bg-blue-50 text-blue-600' },
-  rejected: { label: '삭제 반려', className: 'bg-red-50 text-red-600' },
+  rejected: { label: '삭제 불가', className: 'bg-red-50 text-red-600' },
 };
 
 const PLATFORM_LABELS: Record<string, string> = {

--- a/src/components/report/risk-content/RiskTable.tsx
+++ b/src/components/report/risk-content/RiskTable.tsx
@@ -59,7 +59,7 @@ interface RiskTableProps {
   reportId: string;
   reportedSourceIds: Set<string>;
   riskReportBySourceId: Map<string, string>;
-  /** status !== 'requested' 인 항목 — admin 처리 시작됨, 사용자 취소 불가. */
+  /** pending/resolved/rejected 등 admin 처리 시작 항목 — 사용자 취소 불가. */
   processedSourceIds?: Set<string>;
   onCancelReport: (riskReportId: string) => void;
   editable?: boolean;
@@ -329,7 +329,7 @@ export function RiskTable({
                             </button>
                           ) : !allowReport ? null : processedSourceIds?.has(item.id) ? (
                             <Badge variant="amber" className="px-3 py-1.5">
-                              결과 대기 중
+                              삭제 처리 중
                             </Badge>
                           ) : reportedSourceIds.has(item.id) ? (
                             <button
@@ -461,7 +461,7 @@ export function RiskTable({
                     </button>
                   ) : !allowReport ? null : processedSourceIds?.has(item.id) ? (
                     <div className="w-full py-2.5 rounded-xl text-xs font-semibold bg-amber-50 text-amber-700 text-center">
-                      결과 대기 중
+                      삭제 처리 중
                     </div>
                   ) : reportedSourceIds.has(item.id) ? (
                     <button

--- a/src/hooks/report/useReportMutation.ts
+++ b/src/hooks/report/useReportMutation.ts
@@ -167,6 +167,7 @@ export function useSubmitRiskReport(workspaceId: string, reportId: string) {
       submitRiskReport({ ...input, workspaceId, reportId }),
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: reportKeys.riskReportsAll(workspaceId) });
+      queryClient.invalidateQueries({ queryKey: reportKeys.riskReportsAll('_all') });
       toast.success('신고 대행 요청이 접수되었습니다.');
     },
     onError: (err) => {

--- a/src/lib/api/reportApi.ts
+++ b/src/lib/api/reportApi.ts
@@ -40,6 +40,17 @@ import type {
 
 const supabase = createClient();
 
+async function readRouteError(res: Response, fallback: string): Promise<string> {
+  try {
+    const body = await res.json() as { detail?: unknown; error?: unknown };
+    if (typeof body.detail === 'string' && body.detail.trim()) return body.detail;
+    if (typeof body.error === 'string' && body.error.trim()) return body.error;
+  } catch {
+    // non-JSON error body — fall through to fallback
+  }
+  return fallback;
+}
+
 // ── PostgREST 페이지네이션 헬퍼 ──
 // PostgREST 기본 Range 는 0-999 (1000건 상한). 대용량 워크스페이스 initial 등에서
 // 잘리지 않도록 range + while 루프로 전체 조회.
@@ -1255,15 +1266,6 @@ export async function deleteRiskReport(id: string): Promise<void> {
   if (error) throw error;
 }
 
-// 신고 대상 아이템의 platform_id → risk_reports.source_table
-const RISK_SOURCE_TABLE: Record<string, string> = {
-  naver_news: 'news_items',
-  naver_blog: 'sns_items',
-  youtube: 'sns_items',
-  naver_stock: 'community_items',
-  dcinside: 'community_items',
-};
-
 export interface SubmitRiskReportInput {
   workspaceId: string;
   reportId: string;
@@ -1285,21 +1287,25 @@ export async function submitRiskReport(input: SubmitRiskReportInput): Promise<vo
     fileUrls.push(path);
   }
 
-  const { error } = await supabase.from('risk_reports').insert({
-    workspace_id: workspaceId,
-    report_id: reportId,
-    source_table: RISK_SOURCE_TABLE[item.platform_id] ?? 'community_items',
-    source_id: item.id,
-    platform_id: item.platform_id,
-    title: item.title,
-    link: item.link,
-    critical_type: item.critical_type,
-    reason,
-    evidence,
-    file_urls: fileUrls,
-    status: 'requested',
+  const res = await fetch('/api/risk-report/request', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({
+      workspace_id: workspaceId,
+      report_id: reportId,
+      source_id: item.id,
+      platform_id: item.platform_id,
+      reason,
+      evidence,
+      file_urls: fileUrls,
+    }),
   });
-  if (error) throw error;
+  if (!res.ok) {
+    if (fileUrls.length > 0) {
+      await supabase.storage.from('risk-attachments').remove(fileUrls).catch(() => undefined);
+    }
+    throw new Error(await readRouteError(res, '신고 대행 요청 실패'));
+  }
 }
 
 
@@ -1307,18 +1313,14 @@ export async function updateRiskReport(
   id: string,
   body: { status?: string; admin_note?: string }
 ): Promise<void> {
-  const {
-    data: { session },
-  } = await supabase.auth.getSession();
-  const res = await fetch(`${process.env.NEXT_PUBLIC_API_URL}/api/risk-report/${id}`, {
+  const res = await fetch(`/api/risk-report/${id}`, {
     method: 'PATCH',
     headers: {
       'Content-Type': 'application/json',
-      ...(session?.access_token ? { Authorization: `Bearer ${session.access_token}` } : {}),
     },
     body: JSON.stringify(body),
   });
-  if (!res.ok) throw new Error('상태 업데이트 실패');
+  if (!res.ok) throw new Error(await readRouteError(res, '상태 업데이트 실패'));
 }
 
 // ── 대응 전략 수정 ──


### PR DESCRIPTION
 - 관리자 리스크 관리 페이지에서 `detected` 상태를 `미처리`로 표시합니다.
  - 상태 문구를 정리했습니다.
    - `pending`: 결과 대기 → 삭제 처리 중
    - `rejected`: 삭제 반려 → 삭제 불가
  - 리스크 테이블 스크롤 시 header/body 컬럼 정렬이 어긋나던 문제를 수정했습니다.
  - 리스크 신고 요청/상태 변경 write를 Supabase 직접 호출 대신 Next.js Route Handler를 통하도록 정리했습니다.
  - 리스크 상세 raw 모달의 `critical_type`을 `spam` 같은 raw 값 대신 한글 텍스트로 표시합니다.
